### PR TITLE
feat: Add weekly reading view

### DIFF
--- a/_site/index.html
+++ b/_site/index.html
@@ -32,7 +32,7 @@
   </header>
   <main>
     <h1>BibleProject Reading Plans</h1>
-<p>Browse days or jump directly by scripture reference.</p>
+<p>Browse days, <a href="/weeks/">view by week</a>, or jump directly by scripture reference.</p>
 
 <section class="search">
   <form id="scripture-form" action="/day/" method="get">

--- a/_site/week/1/index.html
+++ b/_site/week/1/index.html
@@ -1,0 +1,306 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 1</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-1">
+    <div class="card-header">
+      <strong>Day 1</strong>
+      <a class="btn" href="/day/1/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Genesis 1</li>
+
+              <li>Genesis 2</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>2 Timothy 3</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/1/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-2">
+    <div class="card-header">
+      <strong>Day 2</strong>
+      <a class="btn" href="/day/2/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Genesis 3</li>
+
+              <li>Genesis 4</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 1</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/2/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-3">
+    <div class="card-header">
+      <strong>Day 3</strong>
+      <a class="btn" href="/day/3/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Genesis 5</li>
+
+              <li>Genesis 6</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 2</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-4">
+    <div class="card-header">
+      <strong>Day 4</strong>
+      <a class="btn" href="/day/4/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Genesis 7</li>
+
+              <li>Genesis 8</li>
+
+              <li>Genesis 9</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 3</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/4/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-5">
+    <div class="card-header">
+      <strong>Day 5</strong>
+      <a class="btn" href="/day/5/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Genesis 10</li>
+
+              <li>Genesis 11</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 4</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-6">
+    <div class="card-header">
+      <strong>Day 6</strong>
+      <a class="btn" href="/day/6/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Genesis 12</li>
+
+              <li>Genesis 13</li>
+
+              <li>Genesis 14</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 5</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/6/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-7">
+    <div class="card-header">
+      <strong>Day 7</strong>
+      <a class="btn" href="/day/7/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Genesis 15</li>
+
+              <li>Genesis 16</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 5</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/7/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+
+  </div>
+  <div>
+    <a href="/week/2/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/10/index.html
+++ b/_site/week/10/index.html
@@ -1,0 +1,284 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 10</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-64">
+    <div class="card-header">
+      <strong>Day 64</strong>
+      <a class="btn" href="/day/64/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Deuteronomy 1</li>
+
+              <li>Deuteronomy 2</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Mark 10</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/64/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-65">
+    <div class="card-header">
+      <strong>Day 65</strong>
+      <a class="btn" href="/day/65/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Deuteronomy 3</li>
+
+              <li>Deuteronomy 4</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Mark 10</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-66">
+    <div class="card-header">
+      <strong>Day 66</strong>
+      <a class="btn" href="/day/66/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Deuteronomy 5</li>
+
+              <li>Deuteronomy 6</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Mark 11</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-67">
+    <div class="card-header">
+      <strong>Day 67</strong>
+      <a class="btn" href="/day/67/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Deuteronomy 7</li>
+
+              <li>Deuteronomy 8</li>
+
+              <li>Deuteronomy 9</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Mark 11</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-68">
+    <div class="card-header">
+      <strong>Day 68</strong>
+      <a class="btn" href="/day/68/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Deuteronomy 10</li>
+
+              <li>Deuteronomy 11</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Mark 12</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-69">
+    <div class="card-header">
+      <strong>Day 69</strong>
+      <a class="btn" href="/day/69/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Deuteronomy 12</li>
+
+              <li>Deuteronomy 13</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Mark 12</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-70">
+    <div class="card-header">
+      <strong>Day 70</strong>
+      <a class="btn" href="/day/70/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Deuteronomy 14</li>
+
+              <li>Deuteronomy 15</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Mark 13</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/9/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/11/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/11/index.html
+++ b/_site/week/11/index.html
@@ -1,0 +1,277 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 11</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-71">
+    <div class="card-header">
+      <strong>Day 71</strong>
+      <a class="btn" href="/day/71/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Deuteronomy 16</li>
+
+              <li>Deuteronomy 17</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Mark 13</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-72">
+    <div class="card-header">
+      <strong>Day 72</strong>
+      <a class="btn" href="/day/72/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Deuteronomy 18</li>
+
+              <li>Deuteronomy 19</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Mark 14</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-73">
+    <div class="card-header">
+      <strong>Day 73</strong>
+      <a class="btn" href="/day/73/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Deuteronomy 20</li>
+
+              <li>Deuteronomy 21</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Mark 14</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-74">
+    <div class="card-header">
+      <strong>Day 74</strong>
+      <a class="btn" href="/day/74/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Deuteronomy 22</li>
+
+              <li>Deuteronomy 23</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Mark 14</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-75">
+    <div class="card-header">
+      <strong>Day 75</strong>
+      <a class="btn" href="/day/75/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Deuteronomy 24</li>
+
+              <li>Deuteronomy 25</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Mark 15</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-76">
+    <div class="card-header">
+      <strong>Day 76</strong>
+      <a class="btn" href="/day/76/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Deuteronomy 26</li>
+
+              <li>Deuteronomy 27</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Mark 15</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-77">
+    <div class="card-header">
+      <strong>Day 77</strong>
+      <a class="btn" href="/day/77/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Deuteronomy 28</li>
+
+              <li>Deuteronomy 29</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Mark 16</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/10/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/12/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/12/index.html
+++ b/_site/week/12/index.html
@@ -1,0 +1,303 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 12</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-78">
+    <div class="card-header">
+      <strong>Day 78</strong>
+      <a class="btn" href="/day/78/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Deuteronomy 30</li>
+
+              <li>Deuteronomy 31</li>
+
+              <li>Deuteronomy 32</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 1</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/78/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-79">
+    <div class="card-header">
+      <strong>Day 79</strong>
+      <a class="btn" href="/day/79/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Deuteronomy 33</li>
+
+              <li>Deuteronomy 34</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 1</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-80">
+    <div class="card-header">
+      <strong>Day 80</strong>
+      <a class="btn" href="/day/80/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Joshua 1</li>
+
+              <li>Joshua 2</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 1</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/80/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-81">
+    <div class="card-header">
+      <strong>Day 81</strong>
+      <a class="btn" href="/day/81/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Joshua 3</li>
+
+              <li>Joshua 4</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 2</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/81/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-82">
+    <div class="card-header">
+      <strong>Day 82</strong>
+      <a class="btn" href="/day/82/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Joshua 5</li>
+
+              <li>Joshua 6</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 3</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/82/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-83">
+    <div class="card-header">
+      <strong>Day 83</strong>
+      <a class="btn" href="/day/83/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Joshua 7</li>
+
+              <li>Joshua 8</li>
+
+              <li>Joshua 9</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 4</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-84">
+    <div class="card-header">
+      <strong>Day 84</strong>
+      <a class="btn" href="/day/84/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Joshua 10</li>
+
+              <li>Joshua 11</li>
+
+              <li>Joshua 12</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 4</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/11/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/13/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/13/index.html
+++ b/_site/week/13/index.html
@@ -1,0 +1,290 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 13</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-85">
+    <div class="card-header">
+      <strong>Day 85</strong>
+      <a class="btn" href="/day/85/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Joshua 13</li>
+
+              <li>Joshua 14</li>
+
+              <li>Joshua 15</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 5</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-86">
+    <div class="card-header">
+      <strong>Day 86</strong>
+      <a class="btn" href="/day/86/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Joshua 16</li>
+
+              <li>Joshua 17</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 5</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-87">
+    <div class="card-header">
+      <strong>Day 87</strong>
+      <a class="btn" href="/day/87/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Joshua 18</li>
+
+              <li>Joshua 19</li>
+
+              <li>Joshua 20</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 6</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-88">
+    <div class="card-header">
+      <strong>Day 88</strong>
+      <a class="btn" href="/day/88/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Joshua 21</li>
+
+              <li>Joshua 22</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 6</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-89">
+    <div class="card-header">
+      <strong>Day 89</strong>
+      <a class="btn" href="/day/89/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Joshua 23</li>
+
+              <li>Joshua 24</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 7</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-90">
+    <div class="card-header">
+      <strong>Day 90</strong>
+      <a class="btn" href="/day/90/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Judges 1</li>
+
+              <li>Judges 2</li>
+
+              <li>Judges 3</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 7</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/90/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-91">
+    <div class="card-header">
+      <strong>Day 91</strong>
+      <a class="btn" href="/day/91/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Judges 4</li>
+
+              <li>Judges 5</li>
+
+              <li>Judges 6</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 8</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/12/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/14/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/14/index.html
+++ b/_site/week/14/index.html
@@ -1,0 +1,313 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 14</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-92">
+    <div class="card-header">
+      <strong>Day 92</strong>
+      <a class="btn" href="/day/92/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Judges 7</li>
+
+              <li>Judges 8</li>
+
+              <li>Judges 9</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 8</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-93">
+    <div class="card-header">
+      <strong>Day 93</strong>
+      <a class="btn" href="/day/93/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Judges 10</li>
+
+              <li>Judges 11</li>
+
+              <li>Judges 12</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 9</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/93/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-94">
+    <div class="card-header">
+      <strong>Day 94</strong>
+      <a class="btn" href="/day/94/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Judges 13</li>
+
+              <li>Judges 14</li>
+
+              <li>Judges 15</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 9</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-95">
+    <div class="card-header">
+      <strong>Day 95</strong>
+      <a class="btn" href="/day/95/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Judges 16</li>
+
+              <li>Judges 17</li>
+
+              <li>Judges 18</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 10</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/95/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-96">
+    <div class="card-header">
+      <strong>Day 96</strong>
+      <a class="btn" href="/day/96/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Judges 19</li>
+
+              <li>Judges 20</li>
+
+              <li>Judges 21</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 10</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-97">
+    <div class="card-header">
+      <strong>Day 97</strong>
+      <a class="btn" href="/day/97/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ruth 1</li>
+
+              <li>Ruth 2</li>
+
+              <li>Ruth 3</li>
+
+              <li>Ruth 4</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 11</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/97/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-98">
+    <div class="card-header">
+      <strong>Day 98</strong>
+      <a class="btn" href="/day/98/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>1 Samuel 1</li>
+
+              <li>1 Samuel 2</li>
+
+              <li>1 Samuel 3</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 11</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/98/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/13/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/15/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/15/index.html
+++ b/_site/week/15/index.html
@@ -1,0 +1,289 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 15</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-99">
+    <div class="card-header">
+      <strong>Day 99</strong>
+      <a class="btn" href="/day/99/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>1 Samuel 4</li>
+
+              <li>1 Samuel 5</li>
+
+              <li>1 Samuel 6</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 12</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-100">
+    <div class="card-header">
+      <strong>Day 100</strong>
+      <a class="btn" href="/day/100/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>1 Samuel 7</li>
+
+              <li>1 Samuel 8</li>
+
+              <li>1 Samuel 9</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 12</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-101">
+    <div class="card-header">
+      <strong>Day 101</strong>
+      <a class="btn" href="/day/101/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>1 Samuel 10</li>
+
+              <li>1 Samuel 11</li>
+
+              <li>1 Samuel 12</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 13</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-102">
+    <div class="card-header">
+      <strong>Day 102</strong>
+      <a class="btn" href="/day/102/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>1 Samuel 13</li>
+
+              <li>1 Samuel 14</li>
+
+              <li>1 Samuel 15</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 13</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-103">
+    <div class="card-header">
+      <strong>Day 103</strong>
+      <a class="btn" href="/day/103/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>1 Samuel 16</li>
+
+              <li>1 Samuel 17</li>
+
+              <li>1 Samuel 18</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 14</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-104">
+    <div class="card-header">
+      <strong>Day 104</strong>
+      <a class="btn" href="/day/104/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>1 Samuel 19</li>
+
+              <li>1 Samuel 20</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 14</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-105">
+    <div class="card-header">
+      <strong>Day 105</strong>
+      <a class="btn" href="/day/105/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>1 Samuel 21</li>
+
+              <li>1 Samuel 22</li>
+
+              <li>1 Samuel 23</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 15</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/14/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/16/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/16/index.html
+++ b/_site/week/16/index.html
@@ -1,0 +1,294 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 16</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-106">
+    <div class="card-header">
+      <strong>Day 106</strong>
+      <a class="btn" href="/day/106/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>1 Samuel 24</li>
+
+              <li>1 Samuel 25</li>
+
+              <li>1 Samuel 26</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 15</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-107">
+    <div class="card-header">
+      <strong>Day 107</strong>
+      <a class="btn" href="/day/107/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>1 Samuel 27</li>
+
+              <li>1 Samuel 28</li>
+
+              <li>1 Samuel 29</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 16</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-108">
+    <div class="card-header">
+      <strong>Day 108</strong>
+      <a class="btn" href="/day/108/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>1 Samuel 30</li>
+
+              <li>1 Samuel 31</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 16</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-109">
+    <div class="card-header">
+      <strong>Day 109</strong>
+      <a class="btn" href="/day/109/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>2 Samuel 1</li>
+
+              <li>2 Samuel 2</li>
+
+              <li>2 Samuel 3</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 17</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/109/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-110">
+    <div class="card-header">
+      <strong>Day 110</strong>
+      <a class="btn" href="/day/110/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>2 Samuel 4</li>
+
+              <li>2 Samuel 5</li>
+
+              <li>2 Samuel 6</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 17</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-111">
+    <div class="card-header">
+      <strong>Day 111</strong>
+      <a class="btn" href="/day/111/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>2 Samuel 7</li>
+
+              <li>2 Samuel 8</li>
+
+              <li>2 Samuel 9</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 18</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-112">
+    <div class="card-header">
+      <strong>Day 112</strong>
+      <a class="btn" href="/day/112/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>2 Samuel 10</li>
+
+              <li>2 Samuel 11</li>
+
+              <li>2 Samuel 12</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 18</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/15/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/17/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/17/index.html
+++ b/_site/week/17/index.html
@@ -1,0 +1,295 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 17</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-113">
+    <div class="card-header">
+      <strong>Day 113</strong>
+      <a class="btn" href="/day/113/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>2 Samuel 13</li>
+
+              <li>2 Samuel 14</li>
+
+              <li>2 Samuel 15</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 19</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/113/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-114">
+    <div class="card-header">
+      <strong>Day 114</strong>
+      <a class="btn" href="/day/114/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>2 Samuel 16</li>
+
+              <li>2 Samuel 17</li>
+
+              <li>2 Samuel 18</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 19</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-115">
+    <div class="card-header">
+      <strong>Day 115</strong>
+      <a class="btn" href="/day/115/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>2 Samuel 19</li>
+
+              <li>2 Samuel 20</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 20</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-116">
+    <div class="card-header">
+      <strong>Day 116</strong>
+      <a class="btn" href="/day/116/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>2 Samuel 21</li>
+
+              <li>2 Samuel 22</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 20</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-117">
+    <div class="card-header">
+      <strong>Day 117</strong>
+      <a class="btn" href="/day/117/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>2 Samuel 23</li>
+
+              <li>2 Samuel 24</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 21</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-118">
+    <div class="card-header">
+      <strong>Day 118</strong>
+      <a class="btn" href="/day/118/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>1 Kings 1</li>
+
+              <li>1 Kings 2</li>
+
+              <li>1 Kings 3</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 21</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/118/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-119">
+    <div class="card-header">
+      <strong>Day 119</strong>
+      <a class="btn" href="/day/119/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>1 Kings 4</li>
+
+              <li>1 Kings 5</li>
+
+              <li>1 Kings 6</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 22</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/16/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/18/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/18/index.html
+++ b/_site/week/18/index.html
@@ -1,0 +1,291 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 18</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-120">
+    <div class="card-header">
+      <strong>Day 120</strong>
+      <a class="btn" href="/day/120/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>1 Kings 7</li>
+
+              <li>1 Kings 8</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 22</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-121">
+    <div class="card-header">
+      <strong>Day 121</strong>
+      <a class="btn" href="/day/121/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>1 Kings 9</li>
+
+              <li>1 Kings 10</li>
+
+              <li>1 Kings 11</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 22</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-122">
+    <div class="card-header">
+      <strong>Day 122</strong>
+      <a class="btn" href="/day/122/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>1 Kings 12</li>
+
+              <li>1 Kings 13</li>
+
+              <li>1 Kings 14</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 23</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-123">
+    <div class="card-header">
+      <strong>Day 123</strong>
+      <a class="btn" href="/day/123/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>1 Kings 15</li>
+
+              <li>1 Kings 16</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 23</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-124">
+    <div class="card-header">
+      <strong>Day 124</strong>
+      <a class="btn" href="/day/124/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>1 Kings 17</li>
+
+              <li>1 Kings 18</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 24</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/124/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-125">
+    <div class="card-header">
+      <strong>Day 125</strong>
+      <a class="btn" href="/day/125/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>1 Kings 19</li>
+
+              <li>1 Kings 20</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Luke 24</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-126">
+    <div class="card-header">
+      <strong>Day 126</strong>
+      <a class="btn" href="/day/126/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>1 Kings 21</li>
+
+              <li>1 Kings 22</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 1</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/126/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/17/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/19/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/19/index.html
+++ b/_site/week/19/index.html
@@ -1,0 +1,286 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 19</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-127">
+    <div class="card-header">
+      <strong>Day 127</strong>
+      <a class="btn" href="/day/127/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>2 Kings 1</li>
+
+              <li>2 Kings 2</li>
+
+              <li>2 Kings 3</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 1</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-128">
+    <div class="card-header">
+      <strong>Day 128</strong>
+      <a class="btn" href="/day/128/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <p class="muted">No OT reading.</p>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 2</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-129">
+    <div class="card-header">
+      <strong>Day 129</strong>
+      <a class="btn" href="/day/129/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>2 Kings 7</li>
+
+              <li>2 Kings 8</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 3</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-130">
+    <div class="card-header">
+      <strong>Day 130</strong>
+      <a class="btn" href="/day/130/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>2 Kings 9</li>
+
+              <li>2 Kings 10</li>
+
+              <li>2 Kings 11</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 3</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-131">
+    <div class="card-header">
+      <strong>Day 131</strong>
+      <a class="btn" href="/day/131/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>2 Kings 12</li>
+
+              <li>2 Kings 13</li>
+
+              <li>2 Kings 14</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 4</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-132">
+    <div class="card-header">
+      <strong>Day 132</strong>
+      <a class="btn" href="/day/132/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>2 Kings 15</li>
+
+              <li>2 Kings 16</li>
+
+              <li>2 Kings 17</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 4</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/132/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-133">
+    <div class="card-header">
+      <strong>Day 133</strong>
+      <a class="btn" href="/day/133/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>2 Kings 18</li>
+
+              <li>2 Kings 19</li>
+
+              <li>2 Kings 20</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 5</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/18/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/20/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/2/index.html
+++ b/_site/week/2/index.html
@@ -1,0 +1,277 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 2</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-8">
+    <div class="card-header">
+      <strong>Day 8</strong>
+      <a class="btn" href="/day/8/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Genesis 17</li>
+
+              <li>Genesis 18</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 6</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-9">
+    <div class="card-header">
+      <strong>Day 9</strong>
+      <a class="btn" href="/day/9/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Genesis 19</li>
+
+              <li>Genesis 20</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 7</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-10">
+    <div class="card-header">
+      <strong>Day 10</strong>
+      <a class="btn" href="/day/10/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Genesis 21</li>
+
+              <li>Genesis 22</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 8</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-11">
+    <div class="card-header">
+      <strong>Day 11</strong>
+      <a class="btn" href="/day/11/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Genesis 23</li>
+
+              <li>Genesis 24</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 9</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-12">
+    <div class="card-header">
+      <strong>Day 12</strong>
+      <a class="btn" href="/day/12/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Genesis 25</li>
+
+              <li>Genesis 26</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 9</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-13">
+    <div class="card-header">
+      <strong>Day 13</strong>
+      <a class="btn" href="/day/13/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Genesis 27</li>
+
+              <li>Genesis 28</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 10</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-14">
+    <div class="card-header">
+      <strong>Day 14</strong>
+      <a class="btn" href="/day/14/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Genesis 29</li>
+
+              <li>Genesis 30</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 10</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/1/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/3/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/20/index.html
+++ b/_site/week/20/index.html
@@ -1,0 +1,296 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 20</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-134">
+    <div class="card-header">
+      <strong>Day 134</strong>
+      <a class="btn" href="/day/134/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>2 Kings 21</li>
+
+              <li>2 Kings 22</li>
+
+              <li>2 Kings 23</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 5</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-135">
+    <div class="card-header">
+      <strong>Day 135</strong>
+      <a class="btn" href="/day/135/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>2 Kings 24</li>
+
+              <li>2 Kings 25</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 6</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-136">
+    <div class="card-header">
+      <strong>Day 136</strong>
+      <a class="btn" href="/day/136/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>1 Chronicles 1</li>
+
+              <li>1 Chronicles 2</li>
+
+              <li>1 Chronicles 3</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 6</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/136/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-137">
+    <div class="card-header">
+      <strong>Day 137</strong>
+      <a class="btn" href="/day/137/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>1 Chronicles 4</li>
+
+              <li>1 Chronicles 5</li>
+
+              <li>1 Chronicles 6</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 6</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-138">
+    <div class="card-header">
+      <strong>Day 138</strong>
+      <a class="btn" href="/day/138/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>1 Chronicles 7</li>
+
+              <li>1 Chronicles 8</li>
+
+              <li>1 Chronicles 9</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 7</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-139">
+    <div class="card-header">
+      <strong>Day 139</strong>
+      <a class="btn" href="/day/139/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>1 Chronicles 10</li>
+
+              <li>1 Chronicles 11</li>
+
+              <li>1 Chronicles 12</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 7</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-140">
+    <div class="card-header">
+      <strong>Day 140</strong>
+      <a class="btn" href="/day/140/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>1 Chronicles 13</li>
+
+              <li>1 Chronicles 14</li>
+
+              <li>1 Chronicles 15</li>
+
+              <li>1 Chronicles 16</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 8</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/19/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/21/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/21/index.html
+++ b/_site/week/21/index.html
@@ -1,0 +1,289 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 21</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-141">
+    <div class="card-header">
+      <strong>Day 141</strong>
+      <a class="btn" href="/day/141/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>1 Chronicles 17</li>
+
+              <li>1 Chronicles 18</li>
+
+              <li>1 Chronicles 19</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 8</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-142">
+    <div class="card-header">
+      <strong>Day 142</strong>
+      <a class="btn" href="/day/142/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>1 Chronicles 20</li>
+
+              <li>1 Chronicles 21</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 8</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-143">
+    <div class="card-header">
+      <strong>Day 143</strong>
+      <a class="btn" href="/day/143/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>1 Chronicles 22</li>
+
+              <li>1 Chronicles 23</li>
+
+              <li>1 Chronicles 24</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 9</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-144">
+    <div class="card-header">
+      <strong>Day 144</strong>
+      <a class="btn" href="/day/144/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>1 Chronicles 25</li>
+
+              <li>1 Chronicles 26</li>
+
+              <li>1 Chronicles 27</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 9</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-145">
+    <div class="card-header">
+      <strong>Day 145</strong>
+      <a class="btn" href="/day/145/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>1 Chronicles 28</li>
+
+              <li>1 Chronicles 29</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 10</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-146">
+    <div class="card-header">
+      <strong>Day 146</strong>
+      <a class="btn" href="/day/146/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>2 Chronicles 1</li>
+
+              <li>2 Chronicles 2</li>
+
+              <li>2 Chronicles 3</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 10</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-147">
+    <div class="card-header">
+      <strong>Day 147</strong>
+      <a class="btn" href="/day/147/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>2 Chronicles 4</li>
+
+              <li>2 Chronicles 5</li>
+
+              <li>2 Chronicles 6</li>
+
+              <li>2 Chronicles 7</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 11</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/20/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/22/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/22/index.html
+++ b/_site/week/22/index.html
@@ -1,0 +1,294 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 22</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-148">
+    <div class="card-header">
+      <strong>Day 148</strong>
+      <a class="btn" href="/day/148/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>2 Chronicles 8</li>
+
+              <li>2 Chronicles 9</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 11</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-149">
+    <div class="card-header">
+      <strong>Day 149</strong>
+      <a class="btn" href="/day/149/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>2 Chronicles 10</li>
+
+              <li>2 Chronicles 11</li>
+
+              <li>2 Chronicles 12</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 11</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-150">
+    <div class="card-header">
+      <strong>Day 150</strong>
+      <a class="btn" href="/day/150/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>2 Chronicles 13</li>
+
+              <li>2 Chronicles 14</li>
+
+              <li>2 Chronicles 15</li>
+
+              <li>2 Chronicles 16</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 12</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-151">
+    <div class="card-header">
+      <strong>Day 151</strong>
+      <a class="btn" href="/day/151/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>2 Chronicles 17</li>
+
+              <li>2 Chronicles 18</li>
+
+              <li>2 Chronicles 19</li>
+
+              <li>2 Chronicles 20</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 12</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-152">
+    <div class="card-header">
+      <strong>Day 152</strong>
+      <a class="btn" href="/day/152/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>2 Chronicles 21</li>
+
+              <li>2 Chronicles 22</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 13</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/152/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-153">
+    <div class="card-header">
+      <strong>Day 153</strong>
+      <a class="btn" href="/day/153/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>2 Chronicles 23</li>
+
+              <li>2 Chronicles 24</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 13</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-154">
+    <div class="card-header">
+      <strong>Day 154</strong>
+      <a class="btn" href="/day/154/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>2 Chronicles 25</li>
+
+              <li>2 Chronicles 26</li>
+
+              <li>2 Chronicles 27</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 14</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/21/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/23/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/23/index.html
+++ b/_site/week/23/index.html
@@ -1,0 +1,292 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 23</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-155">
+    <div class="card-header">
+      <strong>Day 155</strong>
+      <a class="btn" href="/day/155/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>2 Chronicles 28</li>
+
+              <li>2 Chronicles 29</li>
+
+              <li>2 Chronicles 30</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 15</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-156">
+    <div class="card-header">
+      <strong>Day 156</strong>
+      <a class="btn" href="/day/156/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>2 Chronicles 31</li>
+
+              <li>2 Chronicles 32</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 16</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-157">
+    <div class="card-header">
+      <strong>Day 157</strong>
+      <a class="btn" href="/day/157/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>2 Chronicles 33</li>
+
+              <li>2 Chronicles 34</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 16</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-158">
+    <div class="card-header">
+      <strong>Day 158</strong>
+      <a class="btn" href="/day/158/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>2 Chronicles 35</li>
+
+              <li>2 Chronicles 36</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 17</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-159">
+    <div class="card-header">
+      <strong>Day 159</strong>
+      <a class="btn" href="/day/159/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ezra 1</li>
+
+              <li>Ezra 2</li>
+
+              <li>Ezra 3</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 18</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/159/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-160">
+    <div class="card-header">
+      <strong>Day 160</strong>
+      <a class="btn" href="/day/160/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ezra 4</li>
+
+              <li>Ezra 5</li>
+
+              <li>Ezra 6</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 18</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-161">
+    <div class="card-header">
+      <strong>Day 161</strong>
+      <a class="btn" href="/day/161/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ezra 7</li>
+
+              <li>Ezra 8</li>
+
+              <li>Ezra 9</li>
+
+              <li>Ezra 10</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 19</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/22/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/24/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/24/index.html
+++ b/_site/week/24/index.html
@@ -1,0 +1,305 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 24</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-162">
+    <div class="card-header">
+      <strong>Day 162</strong>
+      <a class="btn" href="/day/162/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Nehemiah 1</li>
+
+              <li>Nehemiah 2</li>
+
+              <li>Nehemiah 3</li>
+
+              <li>Nehemiah 4</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 19</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-163">
+    <div class="card-header">
+      <strong>Day 163</strong>
+      <a class="btn" href="/day/163/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Nehemiah 5</li>
+
+              <li>Nehemiah 6</li>
+
+              <li>Nehemiah 7</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 20</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-164">
+    <div class="card-header">
+      <strong>Day 164</strong>
+      <a class="btn" href="/day/164/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Nehemiah 8</li>
+
+              <li>Nehemiah 9</li>
+
+              <li>Nehemiah 10</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>John 21</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-165">
+    <div class="card-header">
+      <strong>Day 165</strong>
+      <a class="btn" href="/day/165/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Nehemiah 11</li>
+
+              <li>Nehemiah 12</li>
+
+              <li>Nehemiah 13</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 1</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/165/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-166">
+    <div class="card-header">
+      <strong>Day 166</strong>
+      <a class="btn" href="/day/166/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Esther 1</li>
+
+              <li>Esther 2</li>
+
+              <li>Esther 3</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 2</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/166/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-167">
+    <div class="card-header">
+      <strong>Day 167</strong>
+      <a class="btn" href="/day/167/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Esther 4</li>
+
+              <li>Esther 5</li>
+
+              <li>Esther 6</li>
+
+              <li>Esther 7</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 2</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-168">
+    <div class="card-header">
+      <strong>Day 168</strong>
+      <a class="btn" href="/day/168/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Esther 8</li>
+
+              <li>Esther 9</li>
+
+              <li>Esther 10</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 3</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/23/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/25/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/25/index.html
+++ b/_site/week/25/index.html
@@ -1,0 +1,293 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 25</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-169">
+    <div class="card-header">
+      <strong>Day 169</strong>
+      <a class="btn" href="/day/169/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Job 1</li>
+
+              <li>Job 2</li>
+
+              <li>Job 3</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 4</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/169/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-170">
+    <div class="card-header">
+      <strong>Day 170</strong>
+      <a class="btn" href="/day/170/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Job 4</li>
+
+              <li>Job 5</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 4</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/170/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-171">
+    <div class="card-header">
+      <strong>Day 171</strong>
+      <a class="btn" href="/day/171/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Job 6</li>
+
+              <li>Job 7</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 5</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-172">
+    <div class="card-header">
+      <strong>Day 172</strong>
+      <a class="btn" href="/day/172/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Job 8</li>
+
+              <li>Job 9</li>
+
+              <li>Job 10</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 5</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-173">
+    <div class="card-header">
+      <strong>Day 173</strong>
+      <a class="btn" href="/day/173/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Job 11</li>
+
+              <li>Job 12</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 6</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-174">
+    <div class="card-header">
+      <strong>Day 174</strong>
+      <a class="btn" href="/day/174/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Job 13</li>
+
+              <li>Job 14</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 7</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-175">
+    <div class="card-header">
+      <strong>Day 175</strong>
+      <a class="btn" href="/day/175/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Job 15</li>
+
+              <li>Job 16</li>
+
+              <li>Job 17</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 7</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/24/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/26/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/26/index.html
+++ b/_site/week/26/index.html
@@ -1,0 +1,289 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 26</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-176">
+    <div class="card-header">
+      <strong>Day 176</strong>
+      <a class="btn" href="/day/176/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Job 18</li>
+
+              <li>Job 19</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 7</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-177">
+    <div class="card-header">
+      <strong>Day 177</strong>
+      <a class="btn" href="/day/177/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Job 20</li>
+
+              <li>Job 21</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 8</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-178">
+    <div class="card-header">
+      <strong>Day 178</strong>
+      <a class="btn" href="/day/178/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Job 22</li>
+
+              <li>Job 23</li>
+
+              <li>Job 24</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 8</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-179">
+    <div class="card-header">
+      <strong>Day 179</strong>
+      <a class="btn" href="/day/179/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Job 25</li>
+
+              <li>Job 26</li>
+
+              <li>Job 27</li>
+
+              <li>Job 28</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 9</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-180">
+    <div class="card-header">
+      <strong>Day 180</strong>
+      <a class="btn" href="/day/180/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Job 29</li>
+
+              <li>Job 30</li>
+
+              <li>Job 31</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 9</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-181">
+    <div class="card-header">
+      <strong>Day 181</strong>
+      <a class="btn" href="/day/181/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Job 32</li>
+
+              <li>Job 33</li>
+
+              <li>Job 34</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 10</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-182">
+    <div class="card-header">
+      <strong>Day 182</strong>
+      <a class="btn" href="/day/182/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Job 35</li>
+
+              <li>Job 36</li>
+
+              <li>Job 37</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 10</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/25/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/27/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/27/index.html
+++ b/_site/week/27/index.html
@@ -1,0 +1,294 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 27</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-183">
+    <div class="card-header">
+      <strong>Day 183</strong>
+      <a class="btn" href="/day/183/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Job 38</li>
+
+              <li>Job 39</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 11</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-184">
+    <div class="card-header">
+      <strong>Day 184</strong>
+      <a class="btn" href="/day/184/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Job 40</li>
+
+              <li>Job 41</li>
+
+              <li>Job 42</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 12</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-185">
+    <div class="card-header">
+      <strong>Day 185</strong>
+      <a class="btn" href="/day/185/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 1</li>
+
+              <li>Psalms 2</li>
+
+              <li>Psalms 3</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 13</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/185/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-186">
+    <div class="card-header">
+      <strong>Day 186</strong>
+      <a class="btn" href="/day/186/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 4</li>
+
+              <li>Psalms 5</li>
+
+              <li>Psalms 6</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 13</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-187">
+    <div class="card-header">
+      <strong>Day 187</strong>
+      <a class="btn" href="/day/187/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 7</li>
+
+              <li>Psalms 8</li>
+
+              <li>Psalms 9</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 14</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-188">
+    <div class="card-header">
+      <strong>Day 188</strong>
+      <a class="btn" href="/day/188/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 10</li>
+
+              <li>Psalms 11</li>
+
+              <li>Psalms 12</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 15</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-189">
+    <div class="card-header">
+      <strong>Day 189</strong>
+      <a class="btn" href="/day/189/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 13</li>
+
+              <li>Psalms 14</li>
+
+              <li>Psalms 15</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 15</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/26/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/28/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/28/index.html
+++ b/_site/week/28/index.html
@@ -1,0 +1,291 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 28</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-190">
+    <div class="card-header">
+      <strong>Day 190</strong>
+      <a class="btn" href="/day/190/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 16</li>
+
+              <li>Psalms 17</li>
+
+              <li>Psalms 18</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 16</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-191">
+    <div class="card-header">
+      <strong>Day 191</strong>
+      <a class="btn" href="/day/191/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 19</li>
+
+              <li>Psalms 20</li>
+
+              <li>Psalms 21</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 16</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-192">
+    <div class="card-header">
+      <strong>Day 192</strong>
+      <a class="btn" href="/day/192/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 22</li>
+
+              <li>Psalms 23</li>
+
+              <li>Psalms 24</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 17</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-193">
+    <div class="card-header">
+      <strong>Day 193</strong>
+      <a class="btn" href="/day/193/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 25</li>
+
+              <li>Psalms 26</li>
+
+              <li>Psalms 27</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 17</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-194">
+    <div class="card-header">
+      <strong>Day 194</strong>
+      <a class="btn" href="/day/194/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 28</li>
+
+              <li>Psalms 29</li>
+
+              <li>Psalms 30</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 18</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-195">
+    <div class="card-header">
+      <strong>Day 195</strong>
+      <a class="btn" href="/day/195/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 31</li>
+
+              <li>Psalms 32</li>
+
+              <li>Psalms 33</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 19</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-196">
+    <div class="card-header">
+      <strong>Day 196</strong>
+      <a class="btn" href="/day/196/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 34</li>
+
+              <li>Psalms 35</li>
+
+              <li>Psalms 36</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 19</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/27/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/29/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/29/index.html
+++ b/_site/week/29/index.html
@@ -1,0 +1,291 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 29</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-197">
+    <div class="card-header">
+      <strong>Day 197</strong>
+      <a class="btn" href="/day/197/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 37</li>
+
+              <li>Psalms 38</li>
+
+              <li>Psalms 39</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 20</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-198">
+    <div class="card-header">
+      <strong>Day 198</strong>
+      <a class="btn" href="/day/198/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 40</li>
+
+              <li>Psalms 41</li>
+
+              <li>Psalms 42</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 20</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-199">
+    <div class="card-header">
+      <strong>Day 199</strong>
+      <a class="btn" href="/day/199/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 43</li>
+
+              <li>Psalms 44</li>
+
+              <li>Psalms 45</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 21</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-200">
+    <div class="card-header">
+      <strong>Day 200</strong>
+      <a class="btn" href="/day/200/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 46</li>
+
+              <li>Psalms 47</li>
+
+              <li>Psalms 48</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 21</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-201">
+    <div class="card-header">
+      <strong>Day 201</strong>
+      <a class="btn" href="/day/201/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 49</li>
+
+              <li>Psalms 50</li>
+
+              <li>Psalms 51</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 22</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-202">
+    <div class="card-header">
+      <strong>Day 202</strong>
+      <a class="btn" href="/day/202/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 52</li>
+
+              <li>Psalms 53</li>
+
+              <li>Psalms 54</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 23</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-203">
+    <div class="card-header">
+      <strong>Day 203</strong>
+      <a class="btn" href="/day/203/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 55</li>
+
+              <li>Psalms 56</li>
+
+              <li>Psalms 57</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 23</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/28/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/30/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/3/index.html
+++ b/_site/week/3/index.html
@@ -1,0 +1,288 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 3</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-15">
+    <div class="card-header">
+      <strong>Day 15</strong>
+      <a class="btn" href="/day/15/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Genesis 31</li>
+
+              <li>Genesis 32</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 11</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-16">
+    <div class="card-header">
+      <strong>Day 16</strong>
+      <a class="btn" href="/day/16/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Genesis 33</li>
+
+              <li>Genesis 34</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 12</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-17">
+    <div class="card-header">
+      <strong>Day 17</strong>
+      <a class="btn" href="/day/17/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Genesis 35</li>
+
+              <li>Genesis 36</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 12</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-18">
+    <div class="card-header">
+      <strong>Day 18</strong>
+      <a class="btn" href="/day/18/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Genesis 37</li>
+
+              <li>Genesis 38</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 13</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-19">
+    <div class="card-header">
+      <strong>Day 19</strong>
+      <a class="btn" href="/day/19/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Genesis 39</li>
+
+              <li>Genesis 40</li>
+
+              <li>Genesis 41</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 13</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-20">
+    <div class="card-header">
+      <strong>Day 20</strong>
+      <a class="btn" href="/day/20/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Genesis 42</li>
+
+              <li>Genesis 43</li>
+
+              <li>Genesis 44</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 14</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/20/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-21">
+    <div class="card-header">
+      <strong>Day 21</strong>
+      <a class="btn" href="/day/21/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Genesis 45</li>
+
+              <li>Genesis 46</li>
+
+              <li>Genesis 47</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 14</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/2/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/4/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/30/index.html
+++ b/_site/week/30/index.html
@@ -1,0 +1,291 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 30</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-204">
+    <div class="card-header">
+      <strong>Day 204</strong>
+      <a class="btn" href="/day/204/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 58</li>
+
+              <li>Psalms 59</li>
+
+              <li>Psalms 60</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 24</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-205">
+    <div class="card-header">
+      <strong>Day 205</strong>
+      <a class="btn" href="/day/205/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 61</li>
+
+              <li>Psalms 62</li>
+
+              <li>Psalms 63</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 25</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-206">
+    <div class="card-header">
+      <strong>Day 206</strong>
+      <a class="btn" href="/day/206/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 64</li>
+
+              <li>Psalms 65</li>
+
+              <li>Psalms 66</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 26</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-207">
+    <div class="card-header">
+      <strong>Day 207</strong>
+      <a class="btn" href="/day/207/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 67</li>
+
+              <li>Psalms 68</li>
+
+              <li>Psalms 69</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 27</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-208">
+    <div class="card-header">
+      <strong>Day 208</strong>
+      <a class="btn" href="/day/208/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 70</li>
+
+              <li>Psalms 71</li>
+
+              <li>Psalms 72</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 27</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-209">
+    <div class="card-header">
+      <strong>Day 209</strong>
+      <a class="btn" href="/day/209/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 73</li>
+
+              <li>Psalms 74</li>
+
+              <li>Psalms 75</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 28</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-210">
+    <div class="card-header">
+      <strong>Day 210</strong>
+      <a class="btn" href="/day/210/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 76</li>
+
+              <li>Psalms 77</li>
+
+              <li>Psalms 78</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Acts 28</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/29/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/31/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/31/index.html
+++ b/_site/week/31/index.html
@@ -1,0 +1,306 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 31</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-211">
+    <div class="card-header">
+      <strong>Day 211</strong>
+      <a class="btn" href="/day/211/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 79</li>
+
+              <li>Psalms 80</li>
+
+              <li>Psalms 81</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Romans 1</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/211/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-212">
+    <div class="card-header">
+      <strong>Day 212</strong>
+      <a class="btn" href="/day/212/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 82</li>
+
+              <li>Psalms 83</li>
+
+              <li>Psalms 84</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Romans 2</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-213">
+    <div class="card-header">
+      <strong>Day 213</strong>
+      <a class="btn" href="/day/213/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 85</li>
+
+              <li>Psalms 86</li>
+
+              <li>Psalms 87</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Romans 3</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-214">
+    <div class="card-header">
+      <strong>Day 214</strong>
+      <a class="btn" href="/day/214/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 88</li>
+
+              <li>Psalms 89</li>
+
+              <li>Psalms 90</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Romans 4</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-215">
+    <div class="card-header">
+      <strong>Day 215</strong>
+      <a class="btn" href="/day/215/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 91</li>
+
+              <li>Psalms 92</li>
+
+              <li>Psalms 93</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Romans 5</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/215/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-216">
+    <div class="card-header">
+      <strong>Day 216</strong>
+      <a class="btn" href="/day/216/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 94</li>
+
+              <li>Psalms 95</li>
+
+              <li>Psalms 96</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Romans 5</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/216/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-217">
+    <div class="card-header">
+      <strong>Day 217</strong>
+      <a class="btn" href="/day/217/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 97</li>
+
+              <li>Psalms 98</li>
+
+              <li>Psalms 99</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Romans 6</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/30/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/32/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/32/index.html
+++ b/_site/week/32/index.html
@@ -1,0 +1,291 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 32</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-218">
+    <div class="card-header">
+      <strong>Day 218</strong>
+      <a class="btn" href="/day/218/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 100</li>
+
+              <li>Psalms 101</li>
+
+              <li>Psalms 102</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Romans 7</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-219">
+    <div class="card-header">
+      <strong>Day 219</strong>
+      <a class="btn" href="/day/219/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 103</li>
+
+              <li>Psalms 104</li>
+
+              <li>Psalms 105</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Romans 8</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-220">
+    <div class="card-header">
+      <strong>Day 220</strong>
+      <a class="btn" href="/day/220/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 106</li>
+
+              <li>Psalms 107</li>
+
+              <li>Psalms 108</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Romans 8</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-221">
+    <div class="card-header">
+      <strong>Day 221</strong>
+      <a class="btn" href="/day/221/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 109</li>
+
+              <li>Psalms 110</li>
+
+              <li>Psalms 111</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Romans 9</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-222">
+    <div class="card-header">
+      <strong>Day 222</strong>
+      <a class="btn" href="/day/222/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 112</li>
+
+              <li>Psalms 113</li>
+
+              <li>Psalms 114</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Romans 10</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-223">
+    <div class="card-header">
+      <strong>Day 223</strong>
+      <a class="btn" href="/day/223/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 115</li>
+
+              <li>Psalms 116</li>
+
+              <li>Psalms 117</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Romans 11</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-224">
+    <div class="card-header">
+      <strong>Day 224</strong>
+      <a class="btn" href="/day/224/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 118</li>
+
+              <li>Psalms 119</li>
+
+              <li>Psalms 120</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Romans 11</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/31/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/33/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/33/index.html
+++ b/_site/week/33/index.html
@@ -1,0 +1,301 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 33</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-225">
+    <div class="card-header">
+      <strong>Day 225</strong>
+      <a class="btn" href="/day/225/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 121</li>
+
+              <li>Psalms 122</li>
+
+              <li>Psalms 123</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Romans 12</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-226">
+    <div class="card-header">
+      <strong>Day 226</strong>
+      <a class="btn" href="/day/226/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 124</li>
+
+              <li>Psalms 125</li>
+
+              <li>Psalms 126</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Romans 13</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/226/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-227">
+    <div class="card-header">
+      <strong>Day 227</strong>
+      <a class="btn" href="/day/227/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 127</li>
+
+              <li>Psalms 128</li>
+
+              <li>Psalms 129</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Romans 14</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-228">
+    <div class="card-header">
+      <strong>Day 228</strong>
+      <a class="btn" href="/day/228/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 130</li>
+
+              <li>Psalms 131</li>
+
+              <li>Psalms 132</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Romans 15</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-229">
+    <div class="card-header">
+      <strong>Day 229</strong>
+      <a class="btn" href="/day/229/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 133</li>
+
+              <li>Psalms 134</li>
+
+              <li>Psalms 135</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Romans 15</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-230">
+    <div class="card-header">
+      <strong>Day 230</strong>
+      <a class="btn" href="/day/230/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 136</li>
+
+              <li>Psalms 137</li>
+
+              <li>Psalms 138</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Romans 16</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-231">
+    <div class="card-header">
+      <strong>Day 231</strong>
+      <a class="btn" href="/day/231/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 139</li>
+
+              <li>Psalms 140</li>
+
+              <li>Psalms 141</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Corinthians 1</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/231/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/32/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/34/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/34/index.html
+++ b/_site/week/34/index.html
@@ -1,0 +1,301 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 34</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-232">
+    <div class="card-header">
+      <strong>Day 232</strong>
+      <a class="btn" href="/day/232/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 142</li>
+
+              <li>Psalms 143</li>
+
+              <li>Psalms 144</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Corinthians 2</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-233">
+    <div class="card-header">
+      <strong>Day 233</strong>
+      <a class="btn" href="/day/233/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 145</li>
+
+              <li>Psalms 146</li>
+
+              <li>Psalms 147</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Corinthians 3</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-234">
+    <div class="card-header">
+      <strong>Day 234</strong>
+      <a class="btn" href="/day/234/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Psalms 148</li>
+
+              <li>Psalms 149</li>
+
+              <li>Psalms 150</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Corinthians 4</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-235">
+    <div class="card-header">
+      <strong>Day 235</strong>
+      <a class="btn" href="/day/235/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Proverbs 1</li>
+
+              <li>Proverbs 2</li>
+
+              <li>Proverbs 3</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Corinthians 5</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/235/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-236">
+    <div class="card-header">
+      <strong>Day 236</strong>
+      <a class="btn" href="/day/236/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Proverbs 4</li>
+
+              <li>Proverbs 5</li>
+
+              <li>Proverbs 6</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Corinthians 6</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/236/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-237">
+    <div class="card-header">
+      <strong>Day 237</strong>
+      <a class="btn" href="/day/237/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Proverbs 7</li>
+
+              <li>Proverbs 8</li>
+
+              <li>Proverbs 9</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Corinthians 7</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-238">
+    <div class="card-header">
+      <strong>Day 238</strong>
+      <a class="btn" href="/day/238/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Proverbs 10</li>
+
+              <li>Proverbs 11</li>
+
+              <li>Proverbs 12</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Corinthians 7</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/33/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/35/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/35/index.html
+++ b/_site/week/35/index.html
@@ -1,0 +1,298 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 35</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-239">
+    <div class="card-header">
+      <strong>Day 239</strong>
+      <a class="btn" href="/day/239/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Proverbs 13</li>
+
+              <li>Proverbs 14</li>
+
+              <li>Proverbs 15</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Corinthians 8</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-240">
+    <div class="card-header">
+      <strong>Day 240</strong>
+      <a class="btn" href="/day/240/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Proverbs 16</li>
+
+              <li>Proverbs 17</li>
+
+              <li>Proverbs 18</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Corinthians 9</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-241">
+    <div class="card-header">
+      <strong>Day 241</strong>
+      <a class="btn" href="/day/241/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Proverbs 19</li>
+
+              <li>Proverbs 20</li>
+
+              <li>Proverbs 21</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Corinthians 10</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-242">
+    <div class="card-header">
+      <strong>Day 242</strong>
+      <a class="btn" href="/day/242/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Proverbs 22</li>
+
+              <li>Proverbs 23</li>
+
+              <li>Proverbs 24</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Corinthians 10</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-243">
+    <div class="card-header">
+      <strong>Day 243</strong>
+      <a class="btn" href="/day/243/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Proverbs 25</li>
+
+              <li>Proverbs 26</li>
+
+              <li>Proverbs 27</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Corinthians 11</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-244">
+    <div class="card-header">
+      <strong>Day 244</strong>
+      <a class="btn" href="/day/244/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Proverbs 28</li>
+
+              <li>Proverbs 29</li>
+
+              <li>Proverbs 30</li>
+
+              <li>Proverbs 31</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Corinthians 11</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-245">
+    <div class="card-header">
+      <strong>Day 245</strong>
+      <a class="btn" href="/day/245/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ecclesiastes 1</li>
+
+              <li>Ecclesiastes 2</li>
+
+              <li>Ecclesiastes 3</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Corinthians 12</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/245/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/34/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/36/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/36/index.html
+++ b/_site/week/36/index.html
@@ -1,0 +1,311 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 36</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-246">
+    <div class="card-header">
+      <strong>Day 246</strong>
+      <a class="btn" href="/day/246/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ecclesiastes 4</li>
+
+              <li>Ecclesiastes 5</li>
+
+              <li>Ecclesiastes 6</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Corinthians 13</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/246/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-247">
+    <div class="card-header">
+      <strong>Day 247</strong>
+      <a class="btn" href="/day/247/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ecclesiastes 7</li>
+
+              <li>Ecclesiastes 8</li>
+
+              <li>Ecclesiastes 9</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Corinthians 14</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-248">
+    <div class="card-header">
+      <strong>Day 248</strong>
+      <a class="btn" href="/day/248/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ecclesiastes 10</li>
+
+              <li>Ecclesiastes 11</li>
+
+              <li>Ecclesiastes 12</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Corinthians 14</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-249">
+    <div class="card-header">
+      <strong>Day 249</strong>
+      <a class="btn" href="/day/249/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Song Of Songs 1</li>
+
+              <li>Song Of Songs 2</li>
+
+              <li>Song Of Songs 3</li>
+
+              <li>Song Of Songs 4</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Corinthians 15</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/249/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-250">
+    <div class="card-header">
+      <strong>Day 250</strong>
+      <a class="btn" href="/day/250/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Song Of Songs 5</li>
+
+              <li>Song Of Songs 6</li>
+
+              <li>Song Of Songs 7</li>
+
+              <li>Song Of Songs 8</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Corinthians 15</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-251">
+    <div class="card-header">
+      <strong>Day 251</strong>
+      <a class="btn" href="/day/251/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 1</li>
+
+              <li>Isaiah 2</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Corinthians 16</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/251/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-252">
+    <div class="card-header">
+      <strong>Day 252</strong>
+      <a class="btn" href="/day/252/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 3</li>
+
+              <li>Isaiah 4</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>2 Corinthians 1</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/252/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/35/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/37/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/37/index.html
+++ b/_site/week/37/index.html
@@ -1,0 +1,282 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 37</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-253">
+    <div class="card-header">
+      <strong>Day 253</strong>
+      <a class="btn" href="/day/253/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 5</li>
+
+              <li>Isaiah 6</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>2 Corinthians 2</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/253/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-254">
+    <div class="card-header">
+      <strong>Day 254</strong>
+      <a class="btn" href="/day/254/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 7</li>
+
+              <li>Isaiah 8</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>2 Corinthians 3</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-255">
+    <div class="card-header">
+      <strong>Day 255</strong>
+      <a class="btn" href="/day/255/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 9</li>
+
+              <li>Isaiah 10</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>2 Corinthians 4</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-256">
+    <div class="card-header">
+      <strong>Day 256</strong>
+      <a class="btn" href="/day/256/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 11</li>
+
+              <li>Isaiah 12</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>2 Corinthians 5</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-257">
+    <div class="card-header">
+      <strong>Day 257</strong>
+      <a class="btn" href="/day/257/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 13</li>
+
+              <li>Isaiah 14</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>2 Corinthians 6</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-258">
+    <div class="card-header">
+      <strong>Day 258</strong>
+      <a class="btn" href="/day/258/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 15</li>
+
+              <li>Isaiah 16</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>2 Corinthians 7</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-259">
+    <div class="card-header">
+      <strong>Day 259</strong>
+      <a class="btn" href="/day/259/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 17</li>
+
+              <li>Isaiah 18</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>2 Corinthians 8</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/36/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/38/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/38/index.html
+++ b/_site/week/38/index.html
@@ -1,0 +1,282 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 38</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-260">
+    <div class="card-header">
+      <strong>Day 260</strong>
+      <a class="btn" href="/day/260/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 19</li>
+
+              <li>Isaiah 20</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>2 Corinthians 9</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-261">
+    <div class="card-header">
+      <strong>Day 261</strong>
+      <a class="btn" href="/day/261/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 21</li>
+
+              <li>Isaiah 22</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>2 Corinthians 10</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-262">
+    <div class="card-header">
+      <strong>Day 262</strong>
+      <a class="btn" href="/day/262/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 23</li>
+
+              <li>Isaiah 24</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>2 Corinthians 11</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-263">
+    <div class="card-header">
+      <strong>Day 263</strong>
+      <a class="btn" href="/day/263/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 25</li>
+
+              <li>Isaiah 26</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>2 Corinthians 11</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-264">
+    <div class="card-header">
+      <strong>Day 264</strong>
+      <a class="btn" href="/day/264/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 27</li>
+
+              <li>Isaiah 28</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>2 Corinthians 12</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-265">
+    <div class="card-header">
+      <strong>Day 265</strong>
+      <a class="btn" href="/day/265/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 29</li>
+
+              <li>Isaiah 30</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>2 Corinthians 13</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-266">
+    <div class="card-header">
+      <strong>Day 266</strong>
+      <a class="btn" href="/day/266/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 31</li>
+
+              <li>Isaiah 32</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Galatians 1</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/266/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/37/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/39/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/39/index.html
+++ b/_site/week/39/index.html
@@ -1,0 +1,287 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 39</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-267">
+    <div class="card-header">
+      <strong>Day 267</strong>
+      <a class="btn" href="/day/267/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 33</li>
+
+              <li>Isaiah 34</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Galatians 2</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-268">
+    <div class="card-header">
+      <strong>Day 268</strong>
+      <a class="btn" href="/day/268/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 35</li>
+
+              <li>Isaiah 36</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Galatians 3</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-269">
+    <div class="card-header">
+      <strong>Day 269</strong>
+      <a class="btn" href="/day/269/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 37</li>
+
+              <li>Isaiah 38</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Galatians 4</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-270">
+    <div class="card-header">
+      <strong>Day 270</strong>
+      <a class="btn" href="/day/270/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 39</li>
+
+              <li>Isaiah 40</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Galatians 5</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/270/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-271">
+    <div class="card-header">
+      <strong>Day 271</strong>
+      <a class="btn" href="/day/271/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 41</li>
+
+              <li>Isaiah 42</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Galatians 6</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-272">
+    <div class="card-header">
+      <strong>Day 272</strong>
+      <a class="btn" href="/day/272/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 43</li>
+
+              <li>Isaiah 44</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Ephesians 1</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/272/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-273">
+    <div class="card-header">
+      <strong>Day 273</strong>
+      <a class="btn" href="/day/273/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 45</li>
+
+              <li>Isaiah 46</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Ephesians 2</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/38/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/40/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/4/index.html
+++ b/_site/week/4/index.html
@@ -1,0 +1,288 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 4</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-22">
+    <div class="card-header">
+      <strong>Day 22</strong>
+      <a class="btn" href="/day/22/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Genesis 48</li>
+
+              <li>Genesis 49</li>
+
+              <li>Genesis 50</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 15</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-23">
+    <div class="card-header">
+      <strong>Day 23</strong>
+      <a class="btn" href="/day/23/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Exodus 1</li>
+
+              <li>Exodus 2</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 15</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/23/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-24">
+    <div class="card-header">
+      <strong>Day 24</strong>
+      <a class="btn" href="/day/24/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Exodus 3</li>
+
+              <li>Exodus 4</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 16</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-25">
+    <div class="card-header">
+      <strong>Day 25</strong>
+      <a class="btn" href="/day/25/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Exodus 5</li>
+
+              <li>Exodus 6</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 17</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-26">
+    <div class="card-header">
+      <strong>Day 26</strong>
+      <a class="btn" href="/day/26/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Exodus 7</li>
+
+              <li>Exodus 8</li>
+
+              <li>Exodus 9</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 18</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-27">
+    <div class="card-header">
+      <strong>Day 27</strong>
+      <a class="btn" href="/day/27/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Exodus 10</li>
+
+              <li>Exodus 11</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 18</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-28">
+    <div class="card-header">
+      <strong>Day 28</strong>
+      <a class="btn" href="/day/28/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Exodus 12</li>
+
+              <li>Exodus 13</li>
+
+              <li>Exodus 14</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 19</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/3/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/5/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/40/index.html
+++ b/_site/week/40/index.html
@@ -1,0 +1,282 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 40</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-274">
+    <div class="card-header">
+      <strong>Day 274</strong>
+      <a class="btn" href="/day/274/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 47</li>
+
+              <li>Isaiah 48</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Ephesians 3</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-275">
+    <div class="card-header">
+      <strong>Day 275</strong>
+      <a class="btn" href="/day/275/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 49</li>
+
+              <li>Isaiah 50</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Ephesians 4</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-276">
+    <div class="card-header">
+      <strong>Day 276</strong>
+      <a class="btn" href="/day/276/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 51</li>
+
+              <li>Isaiah 52</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Ephesians 5</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-277">
+    <div class="card-header">
+      <strong>Day 277</strong>
+      <a class="btn" href="/day/277/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 53</li>
+
+              <li>Isaiah 54</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Ephesians 6</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-278">
+    <div class="card-header">
+      <strong>Day 278</strong>
+      <a class="btn" href="/day/278/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 55</li>
+
+              <li>Isaiah 56</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Philippians 1</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/278/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-279">
+    <div class="card-header">
+      <strong>Day 279</strong>
+      <a class="btn" href="/day/279/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 57</li>
+
+              <li>Isaiah 58</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Philippians 2</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-280">
+    <div class="card-header">
+      <strong>Day 280</strong>
+      <a class="btn" href="/day/280/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 59</li>
+
+              <li>Isaiah 60</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Philippians 3</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/39/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/41/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/41/index.html
+++ b/_site/week/41/index.html
@@ -1,0 +1,292 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 41</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-281">
+    <div class="card-header">
+      <strong>Day 281</strong>
+      <a class="btn" href="/day/281/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 61</li>
+
+              <li>Isaiah 62</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Philippians 4</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-282">
+    <div class="card-header">
+      <strong>Day 282</strong>
+      <a class="btn" href="/day/282/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 63</li>
+
+              <li>Isaiah 64</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Colossians 1</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/282/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-283">
+    <div class="card-header">
+      <strong>Day 283</strong>
+      <a class="btn" href="/day/283/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Isaiah 65</li>
+
+              <li>Isaiah 66</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Colossians 2</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-284">
+    <div class="card-header">
+      <strong>Day 284</strong>
+      <a class="btn" href="/day/284/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Jeremiah 1</li>
+
+              <li>Jeremiah 2</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Colossians 3</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/284/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-285">
+    <div class="card-header">
+      <strong>Day 285</strong>
+      <a class="btn" href="/day/285/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Jeremiah 3</li>
+
+              <li>Jeremiah 4</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Colossians 4</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-286">
+    <div class="card-header">
+      <strong>Day 286</strong>
+      <a class="btn" href="/day/286/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Jeremiah 5</li>
+
+              <li>Jeremiah 6</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Thessalonians 1</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/286/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-287">
+    <div class="card-header">
+      <strong>Day 287</strong>
+      <a class="btn" href="/day/287/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Jeremiah 7</li>
+
+              <li>Jeremiah 8</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Thessalonians 2</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/40/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/42/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/42/index.html
+++ b/_site/week/42/index.html
@@ -1,0 +1,287 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 42</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-288">
+    <div class="card-header">
+      <strong>Day 288</strong>
+      <a class="btn" href="/day/288/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Jeremiah 9</li>
+
+              <li>Jeremiah 10</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Thessalonians 3</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-289">
+    <div class="card-header">
+      <strong>Day 289</strong>
+      <a class="btn" href="/day/289/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Jeremiah 11</li>
+
+              <li>Jeremiah 12</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Thessalonians 4</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-290">
+    <div class="card-header">
+      <strong>Day 290</strong>
+      <a class="btn" href="/day/290/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Jeremiah 13</li>
+
+              <li>Jeremiah 14</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Thessalonians 5</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-291">
+    <div class="card-header">
+      <strong>Day 291</strong>
+      <a class="btn" href="/day/291/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Jeremiah 15</li>
+
+              <li>Jeremiah 16</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>2 Thessalonians 1</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/291/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-292">
+    <div class="card-header">
+      <strong>Day 292</strong>
+      <a class="btn" href="/day/292/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Jeremiah 17</li>
+
+              <li>Jeremiah 18</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>2 Thessalonians 2</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-293">
+    <div class="card-header">
+      <strong>Day 293</strong>
+      <a class="btn" href="/day/293/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Jeremiah 19</li>
+
+              <li>Jeremiah 20</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>2 Thessalonians 3</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-294">
+    <div class="card-header">
+      <strong>Day 294</strong>
+      <a class="btn" href="/day/294/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Jeremiah 21</li>
+
+              <li>Jeremiah 22</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Timothy 1</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/294/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/41/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/43/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/43/index.html
+++ b/_site/week/43/index.html
@@ -1,0 +1,282 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 43</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-295">
+    <div class="card-header">
+      <strong>Day 295</strong>
+      <a class="btn" href="/day/295/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Jeremiah 23</li>
+
+              <li>Jeremiah 24</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Timothy 2</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-296">
+    <div class="card-header">
+      <strong>Day 296</strong>
+      <a class="btn" href="/day/296/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Jeremiah 25</li>
+
+              <li>Jeremiah 26</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Timothy 3</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-297">
+    <div class="card-header">
+      <strong>Day 297</strong>
+      <a class="btn" href="/day/297/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Jeremiah 27</li>
+
+              <li>Jeremiah 28</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Timothy 4</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-298">
+    <div class="card-header">
+      <strong>Day 298</strong>
+      <a class="btn" href="/day/298/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Jeremiah 29</li>
+
+              <li>Jeremiah 30</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Timothy 5</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-299">
+    <div class="card-header">
+      <strong>Day 299</strong>
+      <a class="btn" href="/day/299/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Jeremiah 31</li>
+
+              <li>Jeremiah 32</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Timothy 6</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-300">
+    <div class="card-header">
+      <strong>Day 300</strong>
+      <a class="btn" href="/day/300/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Jeremiah 33</li>
+
+              <li>Jeremiah 34</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>2 Timothy 1</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/300/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-301">
+    <div class="card-header">
+      <strong>Day 301</strong>
+      <a class="btn" href="/day/301/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Jeremiah 35</li>
+
+              <li>Jeremiah 36</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>2 Timothy 2</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/42/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/44/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/44/index.html
+++ b/_site/week/44/index.html
@@ -1,0 +1,292 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 44</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-302">
+    <div class="card-header">
+      <strong>Day 302</strong>
+      <a class="btn" href="/day/302/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Jeremiah 37</li>
+
+              <li>Jeremiah 38</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>2 Timothy 3</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-303">
+    <div class="card-header">
+      <strong>Day 303</strong>
+      <a class="btn" href="/day/303/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Jeremiah 39</li>
+
+              <li>Jeremiah 40</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>2 Timothy 4</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-304">
+    <div class="card-header">
+      <strong>Day 304</strong>
+      <a class="btn" href="/day/304/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Jeremiah 41</li>
+
+              <li>Jeremiah 42</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Titus 1</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/304/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-305">
+    <div class="card-header">
+      <strong>Day 305</strong>
+      <a class="btn" href="/day/305/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Jeremiah 43</li>
+
+              <li>Jeremiah 44</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Titus 2</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-306">
+    <div class="card-header">
+      <strong>Day 306</strong>
+      <a class="btn" href="/day/306/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Jeremiah 45</li>
+
+              <li>Jeremiah 46</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Titus 3</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-307">
+    <div class="card-header">
+      <strong>Day 307</strong>
+      <a class="btn" href="/day/307/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Jeremiah 47</li>
+
+              <li>Jeremiah 48</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Philemon 1</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/307/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-308">
+    <div class="card-header">
+      <strong>Day 308</strong>
+      <a class="btn" href="/day/308/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Jeremiah 49</li>
+
+              <li>Jeremiah 50</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Hebrews 1</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/308/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/43/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/45/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/45/index.html
+++ b/_site/week/45/index.html
@@ -1,0 +1,289 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 45</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-309">
+    <div class="card-header">
+      <strong>Day 309</strong>
+      <a class="btn" href="/day/309/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Jeremiah 51</li>
+
+              <li>Jeremiah 52</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Hebrews 2</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-310">
+    <div class="card-header">
+      <strong>Day 310</strong>
+      <a class="btn" href="/day/310/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Lamentations 1</li>
+
+              <li>Lamentations 2</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Hebrews 3</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/310/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-311">
+    <div class="card-header">
+      <strong>Day 311</strong>
+      <a class="btn" href="/day/311/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Lamentations 3</li>
+
+              <li>Lamentations 4</li>
+
+              <li>Lamentations 5</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Hebrews 4</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-312">
+    <div class="card-header">
+      <strong>Day 312</strong>
+      <a class="btn" href="/day/312/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ezekiel 1</li>
+
+              <li>Ezekiel 2</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Hebrews 5</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/312/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-313">
+    <div class="card-header">
+      <strong>Day 313</strong>
+      <a class="btn" href="/day/313/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ezekiel 3</li>
+
+              <li>Ezekiel 4</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Hebrews 6</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-314">
+    <div class="card-header">
+      <strong>Day 314</strong>
+      <a class="btn" href="/day/314/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ezekiel 5</li>
+
+              <li>Ezekiel 6</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Hebrews 7</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-315">
+    <div class="card-header">
+      <strong>Day 315</strong>
+      <a class="btn" href="/day/315/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ezekiel 7</li>
+
+              <li>Ezekiel 8</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Hebrews 8</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/44/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/46/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/46/index.html
+++ b/_site/week/46/index.html
@@ -1,0 +1,277 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 46</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-316">
+    <div class="card-header">
+      <strong>Day 316</strong>
+      <a class="btn" href="/day/316/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ezekiel 9</li>
+
+              <li>Ezekiel 10</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Hebrews 9</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-317">
+    <div class="card-header">
+      <strong>Day 317</strong>
+      <a class="btn" href="/day/317/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ezekiel 11</li>
+
+              <li>Ezekiel 12</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Hebrews 10</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-318">
+    <div class="card-header">
+      <strong>Day 318</strong>
+      <a class="btn" href="/day/318/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ezekiel 13</li>
+
+              <li>Ezekiel 14</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Hebrews 10</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-319">
+    <div class="card-header">
+      <strong>Day 319</strong>
+      <a class="btn" href="/day/319/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ezekiel 15</li>
+
+              <li>Ezekiel 16</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Hebrews 11</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-320">
+    <div class="card-header">
+      <strong>Day 320</strong>
+      <a class="btn" href="/day/320/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ezekiel 17</li>
+
+              <li>Ezekiel 18</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Hebrews 11</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-321">
+    <div class="card-header">
+      <strong>Day 321</strong>
+      <a class="btn" href="/day/321/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ezekiel 19</li>
+
+              <li>Ezekiel 20</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Hebrews 12</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-322">
+    <div class="card-header">
+      <strong>Day 322</strong>
+      <a class="btn" href="/day/322/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ezekiel 21</li>
+
+              <li>Ezekiel 22</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Hebrews 13</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/45/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/47/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/47/index.html
+++ b/_site/week/47/index.html
@@ -1,0 +1,287 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 47</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-323">
+    <div class="card-header">
+      <strong>Day 323</strong>
+      <a class="btn" href="/day/323/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ezekiel 23</li>
+
+              <li>Ezekiel 24</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>James 1</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/323/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-324">
+    <div class="card-header">
+      <strong>Day 324</strong>
+      <a class="btn" href="/day/324/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ezekiel 25</li>
+
+              <li>Ezekiel 26</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>James 2</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-325">
+    <div class="card-header">
+      <strong>Day 325</strong>
+      <a class="btn" href="/day/325/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ezekiel 27</li>
+
+              <li>Ezekiel 28</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>James 3</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-326">
+    <div class="card-header">
+      <strong>Day 326</strong>
+      <a class="btn" href="/day/326/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ezekiel 29</li>
+
+              <li>Ezekiel 30</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>James 4</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-327">
+    <div class="card-header">
+      <strong>Day 327</strong>
+      <a class="btn" href="/day/327/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ezekiel 31</li>
+
+              <li>Ezekiel 32</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>James 5</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-328">
+    <div class="card-header">
+      <strong>Day 328</strong>
+      <a class="btn" href="/day/328/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ezekiel 33</li>
+
+              <li>Ezekiel 34</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Peter 1</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/328/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-329">
+    <div class="card-header">
+      <strong>Day 329</strong>
+      <a class="btn" href="/day/329/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ezekiel 35</li>
+
+              <li>Ezekiel 36</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Peter 2</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/46/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/48/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/48/index.html
+++ b/_site/week/48/index.html
@@ -1,0 +1,287 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 48</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-330">
+    <div class="card-header">
+      <strong>Day 330</strong>
+      <a class="btn" href="/day/330/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ezekiel 37</li>
+
+              <li>Ezekiel 38</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Peter 3</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-331">
+    <div class="card-header">
+      <strong>Day 331</strong>
+      <a class="btn" href="/day/331/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ezekiel 39</li>
+
+              <li>Ezekiel 40</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Peter 4</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-332">
+    <div class="card-header">
+      <strong>Day 332</strong>
+      <a class="btn" href="/day/332/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ezekiel 41</li>
+
+              <li>Ezekiel 42</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 Peter 5</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-333">
+    <div class="card-header">
+      <strong>Day 333</strong>
+      <a class="btn" href="/day/333/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ezekiel 43</li>
+
+              <li>Ezekiel 44</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>2 Peter 1</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/333/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-334">
+    <div class="card-header">
+      <strong>Day 334</strong>
+      <a class="btn" href="/day/334/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ezekiel 45</li>
+
+              <li>Ezekiel 46</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>2 Peter 2</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-335">
+    <div class="card-header">
+      <strong>Day 335</strong>
+      <a class="btn" href="/day/335/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Ezekiel 47</li>
+
+              <li>Ezekiel 48</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>2 Peter 3</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-336">
+    <div class="card-header">
+      <strong>Day 336</strong>
+      <a class="btn" href="/day/336/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Daniel 1</li>
+
+              <li>Daniel 2</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 John 1</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/336/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/47/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/49/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/49/index.html
+++ b/_site/week/49/index.html
@@ -1,0 +1,298 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 49</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-337">
+    <div class="card-header">
+      <strong>Day 337</strong>
+      <a class="btn" href="/day/337/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Daniel 3</li>
+
+              <li>Daniel 4</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 John 2</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/337/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-338">
+    <div class="card-header">
+      <strong>Day 338</strong>
+      <a class="btn" href="/day/338/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Daniel 5</li>
+
+              <li>Daniel 6</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 John 3</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-339">
+    <div class="card-header">
+      <strong>Day 339</strong>
+      <a class="btn" href="/day/339/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Daniel 7</li>
+
+              <li>Daniel 8</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 John 4</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-340">
+    <div class="card-header">
+      <strong>Day 340</strong>
+      <a class="btn" href="/day/340/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Daniel 9</li>
+
+              <li>Daniel 10</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>1 John 5</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-341">
+    <div class="card-header">
+      <strong>Day 341</strong>
+      <a class="btn" href="/day/341/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Daniel 11</li>
+
+              <li>Daniel 12</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>2 John 1</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-342">
+    <div class="card-header">
+      <strong>Day 342</strong>
+      <a class="btn" href="/day/342/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Hosea 1</li>
+
+              <li>Hosea 2</li>
+
+              <li>Hosea 3</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>3 John 1</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/342/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-343">
+    <div class="card-header">
+      <strong>Day 343</strong>
+      <a class="btn" href="/day/343/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Hosea 4</li>
+
+              <li>Hosea 5</li>
+
+              <li>Hosea 6</li>
+
+              <li>Hosea 7</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Jude 1</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/343/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/48/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/50/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/5/index.html
+++ b/_site/week/5/index.html
@@ -1,0 +1,297 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 5</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-29">
+    <div class="card-header">
+      <strong>Day 29</strong>
+      <a class="btn" href="/day/29/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Exodus 15</li>
+
+              <li>Exodus 16</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 19</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-30">
+    <div class="card-header">
+      <strong>Day 30</strong>
+      <a class="btn" href="/day/30/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Exodus 17</li>
+
+              <li>Exodus 18</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 20</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-31">
+    <div class="card-header">
+      <strong>Day 31</strong>
+      <a class="btn" href="/day/31/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Exodus 19</li>
+
+              <li>Exodus 20</li>
+
+              <li>Exodus 21</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 20</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/31/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-32">
+    <div class="card-header">
+      <strong>Day 32</strong>
+      <a class="btn" href="/day/32/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Exodus 22</li>
+
+              <li>Exodus 23</li>
+
+              <li>Exodus 24</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 21</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/32/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-33">
+    <div class="card-header">
+      <strong>Day 33</strong>
+      <a class="btn" href="/day/33/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Exodus 25</li>
+
+              <li>Exodus 26</li>
+
+              <li>Exodus 27</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 21</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-34">
+    <div class="card-header">
+      <strong>Day 34</strong>
+      <a class="btn" href="/day/34/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Exodus 28</li>
+
+              <li>Exodus 29</li>
+
+              <li>Exodus 30</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 22</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-35">
+    <div class="card-header">
+      <strong>Day 35</strong>
+      <a class="btn" href="/day/35/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Exodus 31</li>
+
+              <li>Exodus 32</li>
+
+              <li>Exodus 33</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 22</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/4/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/6/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/50/index.html
+++ b/_site/week/50/index.html
@@ -1,0 +1,314 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 50</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-344">
+    <div class="card-header">
+      <strong>Day 344</strong>
+      <a class="btn" href="/day/344/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Hosea 8</li>
+
+              <li>Hosea 9</li>
+
+              <li>Hosea 10</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Revelation 1</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/344/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-345">
+    <div class="card-header">
+      <strong>Day 345</strong>
+      <a class="btn" href="/day/345/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Hosea 11</li>
+
+              <li>Hosea 12</li>
+
+              <li>Hosea 13</li>
+
+              <li>Hosea 14</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Revelation 2</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-346">
+    <div class="card-header">
+      <strong>Day 346</strong>
+      <a class="btn" href="/day/346/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Joel 1</li>
+
+              <li>Joel 2</li>
+
+              <li>Joel 3</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Revelation 3</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/346/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-347">
+    <div class="card-header">
+      <strong>Day 347</strong>
+      <a class="btn" href="/day/347/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Amos 1</li>
+
+              <li>Amos 2</li>
+
+              <li>Amos 3</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Revelation 4</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/347/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-348">
+    <div class="card-header">
+      <strong>Day 348</strong>
+      <a class="btn" href="/day/348/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Amos 4</li>
+
+              <li>Amos 5</li>
+
+              <li>Amos 6</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Revelation 5</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-349">
+    <div class="card-header">
+      <strong>Day 349</strong>
+      <a class="btn" href="/day/349/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Amos 7</li>
+
+              <li>Amos 8</li>
+
+              <li>Amos 9</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Revelation 6</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/349/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-350">
+    <div class="card-header">
+      <strong>Day 350</strong>
+      <a class="btn" href="/day/350/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Obadiah 1</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Revelation 7</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/350/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/49/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/51/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/51/index.html
+++ b/_site/week/51/index.html
@@ -1,0 +1,314 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 51</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-351">
+    <div class="card-header">
+      <strong>Day 351</strong>
+      <a class="btn" href="/day/351/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Jonah 1</li>
+
+              <li>Jonah 2</li>
+
+              <li>Jonah 3</li>
+
+              <li>Jonah 4</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Revelation 8</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/351/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-352">
+    <div class="card-header">
+      <strong>Day 352</strong>
+      <a class="btn" href="/day/352/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Micah 1</li>
+
+              <li>Micah 2</li>
+
+              <li>Micah 3</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Revelation 9</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/352/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-353">
+    <div class="card-header">
+      <strong>Day 353</strong>
+      <a class="btn" href="/day/353/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Micah 4</li>
+
+              <li>Micah 5</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Revelation 10</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-354">
+    <div class="card-header">
+      <strong>Day 354</strong>
+      <a class="btn" href="/day/354/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Micah 6</li>
+
+              <li>Micah 7</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Revelation 11</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-355">
+    <div class="card-header">
+      <strong>Day 355</strong>
+      <a class="btn" href="/day/355/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Nahum 1</li>
+
+              <li>Nahum 2</li>
+
+              <li>Nahum 3</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Revelation 12</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/355/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-356">
+    <div class="card-header">
+      <strong>Day 356</strong>
+      <a class="btn" href="/day/356/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Habakkuk 1</li>
+
+              <li>Habakkuk 2</li>
+
+              <li>Habakkuk 3</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Revelation 13</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/356/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-357">
+    <div class="card-header">
+      <strong>Day 357</strong>
+      <a class="btn" href="/day/357/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Zephaniah 1</li>
+
+              <li>Zephaniah 2</li>
+
+              <li>Zephaniah 3</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Revelation 14</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/357/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/50/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/52/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/52/index.html
+++ b/_site/week/52/index.html
@@ -1,0 +1,296 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 52</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-358">
+    <div class="card-header">
+      <strong>Day 358</strong>
+      <a class="btn" href="/day/358/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Haggai 1</li>
+
+              <li>Haggai 2</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Revelation 15</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/358/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-359">
+    <div class="card-header">
+      <strong>Day 359</strong>
+      <a class="btn" href="/day/359/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Zechariah 1</li>
+
+              <li>Zechariah 2</li>
+
+              <li>Zechariah 3</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Revelation 16</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/359/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-360">
+    <div class="card-header">
+      <strong>Day 360</strong>
+      <a class="btn" href="/day/360/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Zechariah 4</li>
+
+              <li>Zechariah 5</li>
+
+              <li>Zechariah 6</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Revelation 17</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-361">
+    <div class="card-header">
+      <strong>Day 361</strong>
+      <a class="btn" href="/day/361/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Zechariah 7</li>
+
+              <li>Zechariah 8</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Revelation 18</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-362">
+    <div class="card-header">
+      <strong>Day 362</strong>
+      <a class="btn" href="/day/362/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Zechariah 9</li>
+
+              <li>Zechariah 10</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Revelation 19</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-363">
+    <div class="card-header">
+      <strong>Day 363</strong>
+      <a class="btn" href="/day/363/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Zechariah 11</li>
+
+              <li>Zechariah 12</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Revelation 20</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/363/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-364">
+    <div class="card-header">
+      <strong>Day 364</strong>
+      <a class="btn" href="/day/364/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Zechariah 13</li>
+
+              <li>Zechariah 14</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Revelation 21</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/51/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/53/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/53/index.html
+++ b/_site/week/53/index.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 53</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-365">
+    <div class="card-header">
+      <strong>Day 365</strong>
+      <a class="btn" href="/day/365/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Malachi 1</li>
+
+              <li>Malachi 2</li>
+
+              <li>Malachi 3</li>
+
+              <li>Malachi 4</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Revelation 22</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/365/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/52/">← Previous Week</a>
+  </div>
+  <div>
+
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/6/index.html
+++ b/_site/week/6/index.html
@@ -1,0 +1,292 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 6</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-36">
+    <div class="card-header">
+      <strong>Day 36</strong>
+      <a class="btn" href="/day/36/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Exodus 34</li>
+
+              <li>Exodus 35</li>
+
+              <li>Exodus 36</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 23</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-37">
+    <div class="card-header">
+      <strong>Day 37</strong>
+      <a class="btn" href="/day/37/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Exodus 37</li>
+
+              <li>Exodus 38</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 23</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-38">
+    <div class="card-header">
+      <strong>Day 38</strong>
+      <a class="btn" href="/day/38/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Exodus 39</li>
+
+              <li>Exodus 40</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 24</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-39">
+    <div class="card-header">
+      <strong>Day 39</strong>
+      <a class="btn" href="/day/39/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Leviticus 1</li>
+
+              <li>Leviticus 2</li>
+
+              <li>Leviticus 3</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 24</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/39/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-40">
+    <div class="card-header">
+      <strong>Day 40</strong>
+      <a class="btn" href="/day/40/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Leviticus 4</li>
+
+              <li>Leviticus 5</li>
+
+              <li>Leviticus 6</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 25</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-41">
+    <div class="card-header">
+      <strong>Day 41</strong>
+      <a class="btn" href="/day/41/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Leviticus 7</li>
+
+              <li>Leviticus 8</li>
+
+              <li>Leviticus 9</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 25</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-42">
+    <div class="card-header">
+      <strong>Day 42</strong>
+      <a class="btn" href="/day/42/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Leviticus 10</li>
+
+              <li>Leviticus 11</li>
+
+              <li>Leviticus 12</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 26</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/5/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/7/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/7/index.html
+++ b/_site/week/7/index.html
@@ -1,0 +1,294 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 7</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-43">
+    <div class="card-header">
+      <strong>Day 43</strong>
+      <a class="btn" href="/day/43/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Leviticus 13</li>
+
+              <li>Leviticus 14</li>
+
+              <li>Leviticus 15</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 26</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-44">
+    <div class="card-header">
+      <strong>Day 44</strong>
+      <a class="btn" href="/day/44/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Leviticus 16</li>
+
+              <li>Leviticus 17</li>
+
+              <li>Leviticus 18</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 26</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/44/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-45">
+    <div class="card-header">
+      <strong>Day 45</strong>
+      <a class="btn" href="/day/45/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <p class="muted">No OT reading.</p>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 27</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-46">
+    <div class="card-header">
+      <strong>Day 46</strong>
+      <a class="btn" href="/day/46/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Leviticus 22</li>
+
+              <li>Leviticus 23</li>
+
+              <li>Leviticus 24</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 27</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-47">
+    <div class="card-header">
+      <strong>Day 47</strong>
+      <a class="btn" href="/day/47/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Leviticus 25</li>
+
+              <li>Leviticus 26</li>
+
+              <li>Leviticus 27</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Matthew 28</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/47/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-48">
+    <div class="card-header">
+      <strong>Day 48</strong>
+      <a class="btn" href="/day/48/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Numbers 1</li>
+
+              <li>Numbers 2</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Mark 1</li>
+
+          </ul>
+
+      </section>
+
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/48/">Open the day</a> to watch.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-49">
+    <div class="card-header">
+      <strong>Day 49</strong>
+      <a class="btn" href="/day/49/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Numbers 3</li>
+
+              <li>Numbers 4</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Mark 1</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/6/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/8/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/8/index.html
+++ b/_site/week/8/index.html
@@ -1,0 +1,283 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 8</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-50">
+    <div class="card-header">
+      <strong>Day 50</strong>
+      <a class="btn" href="/day/50/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Numbers 5</li>
+
+              <li>Numbers 6</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Mark 2</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-51">
+    <div class="card-header">
+      <strong>Day 51</strong>
+      <a class="btn" href="/day/51/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Numbers 7</li>
+
+              <li>Numbers 8</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Mark 3</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-52">
+    <div class="card-header">
+      <strong>Day 52</strong>
+      <a class="btn" href="/day/52/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Numbers 9</li>
+
+              <li>Numbers 10</li>
+
+              <li>Numbers 11</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Mark 4</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-53">
+    <div class="card-header">
+      <strong>Day 53</strong>
+      <a class="btn" href="/day/53/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Numbers 12</li>
+
+              <li>Numbers 13</li>
+
+              <li>Numbers 14</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Mark 4</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-54">
+    <div class="card-header">
+      <strong>Day 54</strong>
+      <a class="btn" href="/day/54/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Numbers 15</li>
+
+              <li>Numbers 16</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Mark 5</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-55">
+    <div class="card-header">
+      <strong>Day 55</strong>
+      <a class="btn" href="/day/55/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Numbers 17</li>
+
+              <li>Numbers 18</li>
+
+              <li>Numbers 19</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Mark 5</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-56">
+    <div class="card-header">
+      <strong>Day 56</strong>
+      <a class="btn" href="/day/56/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Numbers 20</li>
+
+              <li>Numbers 21</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Mark 6</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/7/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/9/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/week/9/index.html
+++ b/_site/week/9/index.html
@@ -1,0 +1,279 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+
+<h1>Week 9</h1>
+
+<div class="grid week-view">
+
+  <div class="card" id="day-57">
+    <div class="card-header">
+      <strong>Day 57</strong>
+      <a class="btn" href="/day/57/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Numbers 22</li>
+
+              <li>Numbers 23</li>
+
+              <li>Numbers 24</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Mark 6</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-58">
+    <div class="card-header">
+      <strong>Day 58</strong>
+      <a class="btn" href="/day/58/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Numbers 25</li>
+
+              <li>Numbers 26</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Mark 7</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-59">
+    <div class="card-header">
+      <strong>Day 59</strong>
+      <a class="btn" href="/day/59/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Numbers 27</li>
+
+              <li>Numbers 28</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Mark 7</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-60">
+    <div class="card-header">
+      <strong>Day 60</strong>
+      <a class="btn" href="/day/60/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Numbers 29</li>
+
+              <li>Numbers 30</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Mark 8</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-61">
+    <div class="card-header">
+      <strong>Day 61</strong>
+      <a class="btn" href="/day/61/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Numbers 31</li>
+
+              <li>Numbers 32</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Mark 8</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-62">
+    <div class="card-header">
+      <strong>Day 62</strong>
+      <a class="btn" href="/day/62/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Numbers 33</li>
+
+              <li>Numbers 34</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Mark 9</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+  <div class="card" id="day-63">
+    <div class="card-header">
+      <strong>Day 63</strong>
+      <a class="btn" href="/day/63/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+
+          <ul>
+
+              <li>Numbers 35</li>
+
+              <li>Numbers 36</li>
+
+          </ul>
+
+      </section>
+      <section>
+        <h2>New Testament</h2>
+
+          <ul>
+
+              <li>Mark 9</li>
+
+          </ul>
+
+      </section>
+
+    </div>
+  </div>
+
+</div>
+
+<div class="nav">
+  <div>
+    <a href="/week/8/">← Previous Week</a>
+  </div>
+  <div>
+    <a href="/week/10/">Next Week →</a>
+  </div>
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/_site/weeks/index.html
+++ b/_site/weeks/index.html
@@ -1,0 +1,362 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BibleProject Reading Plans</title>
+  <style>
+    :root { --maxw: 900px; --accent: #0b6efd; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+    header { background: #111; color: #fff; }
+    header .wrap { max-width: var(--maxw); margin: 0 auto; padding: 1rem; display:flex; gap:1rem; align-items:center; }
+    header a { color: #fff; text-decoration: none; }
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem; }
+    a { color: var(--accent); }
+    .grid { display: grid; gap: .75rem; }
+    .day-list { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+    .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: .75rem .9rem; }
+    .muted { color: #6b7280; }
+    .videos iframe { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 8px; }
+    .nav { display:flex; justify-content: space-between; margin-top: 1rem; }
+    .search { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; }
+    .search input[type="text"] { flex:1; min-width:250px; padding:.5rem .6rem; border:1px solid #d1d5db; border-radius:6px; }
+    .btn { display:inline-block; padding:.4rem .7rem; background: var(--accent); color:#fff; border-radius:6px; text-decoration:none; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a href="/">BibleProject Plans</a>
+      <span class="muted">· OT + NT with videos</span>
+    </div>
+  </header>
+  <main>
+    <h1>Weekly Reading Plan</h1>
+<p>Browse the reading plan by week.</p>
+
+<div class="grid day-list">
+
+    <div class="card">
+      <div><strong>Week 1</strong></div>
+      <div class="muted">Day 1 - Day 7</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/1/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 2</strong></div>
+      <div class="muted">Day 8 - Day 14</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/2/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 3</strong></div>
+      <div class="muted">Day 15 - Day 21</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/3/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 4</strong></div>
+      <div class="muted">Day 22 - Day 28</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/4/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 5</strong></div>
+      <div class="muted">Day 29 - Day 35</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/5/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 6</strong></div>
+      <div class="muted">Day 36 - Day 42</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/6/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 7</strong></div>
+      <div class="muted">Day 43 - Day 49</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/7/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 8</strong></div>
+      <div class="muted">Day 50 - Day 56</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/8/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 9</strong></div>
+      <div class="muted">Day 57 - Day 63</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/9/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 10</strong></div>
+      <div class="muted">Day 64 - Day 70</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/10/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 11</strong></div>
+      <div class="muted">Day 71 - Day 77</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/11/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 12</strong></div>
+      <div class="muted">Day 78 - Day 84</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/12/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 13</strong></div>
+      <div class="muted">Day 85 - Day 91</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/13/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 14</strong></div>
+      <div class="muted">Day 92 - Day 98</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/14/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 15</strong></div>
+      <div class="muted">Day 99 - Day 105</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/15/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 16</strong></div>
+      <div class="muted">Day 106 - Day 112</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/16/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 17</strong></div>
+      <div class="muted">Day 113 - Day 119</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/17/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 18</strong></div>
+      <div class="muted">Day 120 - Day 126</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/18/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 19</strong></div>
+      <div class="muted">Day 127 - Day 133</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/19/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 20</strong></div>
+      <div class="muted">Day 134 - Day 140</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/20/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 21</strong></div>
+      <div class="muted">Day 141 - Day 147</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/21/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 22</strong></div>
+      <div class="muted">Day 148 - Day 154</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/22/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 23</strong></div>
+      <div class="muted">Day 155 - Day 161</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/23/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 24</strong></div>
+      <div class="muted">Day 162 - Day 168</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/24/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 25</strong></div>
+      <div class="muted">Day 169 - Day 175</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/25/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 26</strong></div>
+      <div class="muted">Day 176 - Day 182</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/26/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 27</strong></div>
+      <div class="muted">Day 183 - Day 189</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/27/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 28</strong></div>
+      <div class="muted">Day 190 - Day 196</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/28/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 29</strong></div>
+      <div class="muted">Day 197 - Day 203</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/29/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 30</strong></div>
+      <div class="muted">Day 204 - Day 210</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/30/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 31</strong></div>
+      <div class="muted">Day 211 - Day 217</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/31/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 32</strong></div>
+      <div class="muted">Day 218 - Day 224</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/32/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 33</strong></div>
+      <div class="muted">Day 225 - Day 231</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/33/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 34</strong></div>
+      <div class="muted">Day 232 - Day 238</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/34/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 35</strong></div>
+      <div class="muted">Day 239 - Day 245</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/35/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 36</strong></div>
+      <div class="muted">Day 246 - Day 252</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/36/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 37</strong></div>
+      <div class="muted">Day 253 - Day 259</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/37/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 38</strong></div>
+      <div class="muted">Day 260 - Day 266</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/38/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 39</strong></div>
+      <div class="muted">Day 267 - Day 273</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/39/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 40</strong></div>
+      <div class="muted">Day 274 - Day 280</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/40/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 41</strong></div>
+      <div class="muted">Day 281 - Day 287</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/41/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 42</strong></div>
+      <div class="muted">Day 288 - Day 294</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/42/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 43</strong></div>
+      <div class="muted">Day 295 - Day 301</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/43/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 44</strong></div>
+      <div class="muted">Day 302 - Day 308</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/44/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 45</strong></div>
+      <div class="muted">Day 309 - Day 315</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/45/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 46</strong></div>
+      <div class="muted">Day 316 - Day 322</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/46/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 47</strong></div>
+      <div class="muted">Day 323 - Day 329</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/47/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 48</strong></div>
+      <div class="muted">Day 330 - Day 336</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/48/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 49</strong></div>
+      <div class="muted">Day 337 - Day 343</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/49/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 50</strong></div>
+      <div class="muted">Day 344 - Day 350</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/50/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 51</strong></div>
+      <div class="muted">Day 351 - Day 357</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/51/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 52</strong></div>
+      <div class="muted">Day 358 - Day 364</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/52/">Open Week</a></div>
+    </div>
+
+    <div class="card">
+      <div><strong>Week 53</strong></div>
+      <div class="muted">Day 365 - Day 365</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/53/">Open Week</a></div>
+    </div>
+
+</div>
+
+  </main>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/src/_data/plan.js
+++ b/src/_data/plan.js
@@ -72,5 +72,16 @@ module.exports = () => {
   }
   scriptureIndex.sort((a, b) => a.ref.localeCompare(b.ref) || a.day - b.day);
 
-  return { days, scriptureIndex };
+  const weeks = [];
+  if (days && days.length) {
+    for (let i = 0; i < days.length; i += 7) {
+      const week = days.slice(i, i + 7);
+      weeks.push({
+        weekNumber: (i / 7) + 1,
+        days: week,
+      });
+    }
+  }
+
+  return { days, scriptureIndex, weeks };
 };

--- a/src/index.liquid
+++ b/src/index.liquid
@@ -3,7 +3,7 @@ layout: base
 permalink: "/"
 ---
 <h1>BibleProject Reading Plans</h1>
-<p>Browse days or jump directly by scripture reference.</p>
+<p>Browse days, <a href="/weeks/">view by week</a>, or jump directly by scripture reference.</p>
 
 <section class="search">
   <form id="scripture-form" action="/day/" method="get">

--- a/src/week.liquid
+++ b/src/week.liquid
@@ -1,0 +1,62 @@
+---
+layout: base
+pagination:
+  data: plan.weeks
+  size: 1
+  alias: w
+permalink: "/week/{{ w.weekNumber }}/"
+---
+{% assign week = w %}
+<h1>Week {{ week.weekNumber }}</h1>
+
+<div class="grid week-view">
+  {% for d in week.days %}
+  <div class="card" id="day-{{ d.day }}">
+    <div class="card-header">
+      <strong>Day {{ d.day }}</strong>
+      <a class="btn" href="/day/{{ d.day }}/">Go to Day</a>
+    </div>
+    <div class="card-content">
+      <section>
+        <h2>Old Testament</h2>
+        {% if d.otReadings.size > 0 %}
+          <ul>
+            {% for ref in d.otReadings %}
+              <li>{{ ref }}</li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <p class="muted">No OT reading.</p>
+        {% endif %}
+      </section>
+      <section>
+        <h2>New Testament</h2>
+        {% if d.ntReadings.size > 0 %}
+          <ul>
+            {% for ref in d.ntReadings %}
+              <li>{{ ref }}</li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <p class="muted">No NT reading.</p>
+        {% endif %}
+      </section>
+      {% if d.videos and d.videos.size > 0 %}
+      <section>
+        <h2>Videos</h2>
+        <p class="muted">🎬 This day has videos. <a href="/day/{{ d.day }}/">Open the day</a> to watch.</p>
+      </section>
+      {% endif %}
+    </div>
+  </div>
+  {% endfor %}
+</div>
+
+<div class="nav">
+  <div>
+    {% if week.weekNumber > 1 %}<a href="/week/{{ week.weekNumber | minus: 1 }}/">← Previous Week</a>{% endif %}
+  </div>
+  <div>
+    {% if week.weekNumber < 53 %}<a href="/week/{{ week.weekNumber | plus: 1 }}/">Next Week →</a>{% endif %}
+  </div>
+</div>

--- a/src/weeks.liquid
+++ b/src/weeks.liquid
@@ -1,0 +1,16 @@
+---
+layout: base
+permalink: "/weeks/"
+---
+<h1>Weekly Reading Plan</h1>
+<p>Browse the reading plan by week.</p>
+
+<div class="grid day-list">
+  {% for w in plan.weeks %}
+    <div class="card">
+      <div><strong>Week {{ w.weekNumber }}</strong></div>
+      <div class="muted">Day {{ w.days[0].day }} - Day {{ w.days | last | map: "day" }}</div>
+      <div style="margin-top:.5rem"><a class="btn" href="/week/{{ w.weekNumber }}/">Open Week</a></div>
+    </div>
+  {% endfor %}
+</div>


### PR DESCRIPTION
This feature adds a new weekly view to the Bible reading plan, allowing you to see a full week of readings on a single page.

The key changes are:
- A new `/weeks` page that lists all the weeks in the reading plan.
- A new `/week/{weekNumber}` page that displays the readings for each day of that week.
- The data in `src/_data/plan.js` is now grouped by week.
- A link to the new weekly view has been added to the main page.

This helps you to better plan your reading by providing a higher-level overview of the plan.