### PR TITLE
Reframe UI with scholarly minimalist design system

### DIFF
--- a/src/404.liquid
+++ b/src/404.liquid
@@ -4,7 +4,7 @@ layout: base.liquid
 title: "Page not found"
 ---
 <header class="mb-5">
-  <h1 class="text-2xl font-semibold tracking-tight text-slate-900">Page not found</h1>
-  <p class="mt-1 text-slate-600">Sorry, we couldn't find that page.</p>
+  <h1>Page not found</h1>
+  <p class="mt-1 text-text-secondary">Sorry, we couldn't find that page.</p>
 </header>
-<p><a class="text-blue-600 hover:text-blue-700 underline underline-offset-2" href="/">Go back home</a></p>
+<p><a class="text-accent-teal underline" href="/">Go back home</a></p>

--- a/src/_includes/justice-scriptures.liquid
+++ b/src/_includes/justice-scriptures.liquid
@@ -6,13 +6,13 @@
 {% endcomment %}
 
 {% if justice_refs and justice_refs.size > 0 %}
-<section class="prose prose-slate max-w-none {{ margin_top | default: 'mt-5' }}">
+<section class="prose max-w-none {{ margin_top | default: 'mt-5' }}">
   <h2>Justice Scriptures</h2>
   <ul class="not-prose list-disc pl-5 space-y-1">
     {% for ref in justice_refs %}
-      <li class="text-slate-700">{{ ref }}</li>
+      <li>{{ ref }}</li>
     {% endfor %}
   </ul>
-  <p class="text-slate-500 text-sm">These are justice-related verses that fall within today's Old Testament chapters.</p>
+  <p class="text-text-secondary text-sm">These are justice-related verses that fall within today's Old Testament chapters.</p>
 </section>
 {% endif %}

--- a/src/_includes/navigation-buttons.liquid
+++ b/src/_includes/navigation-buttons.liquid
@@ -13,27 +13,23 @@
   <div>
     {% if current_number > 1 %}
       {% assign prev_number = current_number | minus: 1 %}
-      <a class="inline-flex items-center rounded-md border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 hover:bg-slate-50" href="/{{ type }}/{{ prev_number }}/">
-        ← Previous{% if type == "week" %} Week{% endif %}
-      </a>
+      <a class="btn-secondary" href="/{{ type }}/{{ prev_number }}/">← Previous{% if type == "week" %} Week{% endif %}</a>
     {% endif %}
   </div>
-  
+
   {% if back_to_text and back_to_url %}
-    <a class="inline-flex items-center rounded-md border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 hover:bg-slate-50" href="{{ back_to_url }}">{{ back_to_text }}</a>
+    <a class="btn-secondary" href="{{ back_to_url }}">{{ back_to_text }}</a>
   {% endif %}
-  
+
   <div>
     {% assign max_num = max_number | default: 365 %}
     {% if type == "week" %}
       {% assign max_num = 53 %}
     {% endif %}
-    
+
     {% if current_number < max_num %}
       {% assign next_number = current_number | plus: 1 %}
-      <a class="inline-flex items-center rounded-md border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 hover:bg-slate-50" href="/{{ type }}/{{ next_number }}/">
-        Next{% if type == "week" %} Week{% endif %} →
-      </a>
+      <a class="btn-primary" href="/{{ type }}/{{ next_number }}/">Next{% if type == "week" %} Week{% endif %} →</a>
     {% endif %}
   </div>
 </div>

--- a/src/_includes/scripture-readings.liquid
+++ b/src/_includes/scripture-readings.liquid
@@ -7,19 +7,19 @@
   - no_reading_text: Text to show when no readings (default: "No reading.")
 {% endcomment %}
 
-<section class="prose prose-slate max-w-none{% if margin_top %} {{ margin_top }}{% endif %}">
+<section class="prose max-w-none{% if margin_top %} {{ margin_top }}{% endif %}">
   <h2>{{ heading }}</h2>
   {% if readings and readings.size > 0 %}
     <ul class="not-prose list-disc pl-5 space-y-1">
       {% for ref in readings %}
-        <li class="text-slate-700">{{ ref }}</li>
+        <li>{{ ref }}</li>
       {% endfor %}
     </ul>
   {% else %}
-    <p class="text-slate-500">{{ no_reading_text | default: "No reading." }}</p>
+    <p class="text-text-secondary">{{ no_reading_text | default: "No reading." }}</p>
   {% endif %}
   
   {% if url %}
-    <p><a class="text-blue-600 hover:text-blue-700 underline underline-offset-2" href="{{ url }}" target="_blank" rel="noopener">Read on Bible.com</a></p>
+    <p><a class="text-accent-teal underline" href="{{ url }}" target="_blank" rel="noopener">Read on Bible.com</a></p>
   {% endif %}
 </section>

--- a/src/_includes/videos-section.liquid
+++ b/src/_includes/videos-section.liquid
@@ -11,32 +11,32 @@
 <section class="{{ margin_top | default: 'mt-6' }}">
   {% assign heading_level = heading_level | default: "h2" %}
   {% if heading_level == "h2" %}
-    <h2 class="text-base font-semibold text-slate-900 mb-2.5">{{ heading | default: "Videos" }}</h2>
+    <h2 class="text-base font-semibold mb-2.5">{{ heading | default: "Videos" }}</h2>
   {% elsif heading_level == "h3" %}
-    <h3 class="text-base font-semibold text-slate-900 mb-2.5">{{ heading | default: "Videos" }}</h3>
+    <h3 class="text-base font-semibold mb-2.5">{{ heading | default: "Videos" }}</h3>
   {% endif %}
   
   {% if videos and videos.size > 0 %}
     <div class="{{ grid_classes | default: 'grid grid-cols-1 gap-3 sm:grid-cols-2' }} videos">
       {% for v in videos %}
-        <div class="rounded-lg overflow-hidden shadow ring-1 ring-slate-200 relative">
-          <div class="lazy-video w-full aspect-video bg-slate-100 flex items-center justify-center cursor-pointer" 
+        <div class="rounded-sm overflow-hidden shadow ring-1 ring-border relative">
+          <div class="lazy-video w-full aspect-video bg-border flex items-center justify-center cursor-pointer"
                data-src="{{ v }}"
                role="button"
                tabindex="0"
                aria-label="Load BibleProject Video">
             <div class="text-center">
-              <svg class="w-16 h-16 mx-auto text-slate-400 mb-2" fill="currentColor" viewBox="0 0 20 20">
+              <svg class="w-16 h-16 mx-auto text-text-secondary mb-2" fill="currentColor" viewBox="0 0 20 20">
                 <path d="M6.267 3.455a3.066 3.066 0 001.745-.723 3.066 3.066 0 013.976 0 3.066 3.066 0 001.745.723 3.066 3.066 0 012.812 2.812c.051.643.304 1.254.723 1.745a3.066 3.066 0 010 3.976 3.066 3.066 0 00-.723 1.745 3.066 3.066 0 01-2.812 2.812 3.066 3.066 0 00-1.745.723 3.066 3.066 0 01-3.976 0 3.066 3.066 0 00-1.745-.723 3.066 3.066 0 01-2.812-2.812 3.066 3.066 0 00-.723-1.745 3.066 3.066 0 010-3.976 3.066 3.066 0 00.723-1.745 3.066 3.066 0 012.812-2.812zm7.44 5.252a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" />
               </svg>
-              <p class="text-sm text-slate-600 font-medium">Click to load video</p>
-              <p class="text-xs text-slate-500">Saves bandwidth</p>
+              <p class="text-sm text-text-secondary font-medium">Click to load video</p>
+              <p class="text-xs text-text-secondary">Saves bandwidth</p>
             </div>
           </div>
         </div>
       {% endfor %}
     </div>
   {% else %}
-    <p class="text-slate-500">No videos for this day.</p>
+    <p class="text-text-secondary">No videos for this day.</p>
   {% endif %}
 </section>

--- a/src/_layouts/base.liquid
+++ b/src/_layouts/base.liquid
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% if title %}{{ title }} · {% endif %}{{ site.title | default: "BibleProject Reading Plans" }}</title>
   <meta name="description" content="{{ description | default: site.description }}">
-  <meta name="theme-color" content="#ea580c">
+    <meta name="theme-color" content="#0C5A65">
   <meta property="og:title" content="{% if title %}{{ title }}{% else %}{{ site.title }}{% endif %}">
   <meta property="og:description" content="{{ description | default: site.description }}">
   <meta property="og:type" content="website">
@@ -22,33 +22,26 @@
   <!-- Mobile fallback CSS for enhanced accessibility -->
   <link rel="stylesheet" href="/assets/mobile-fallback.css">
 </head>
-<body class="min-h-full bg-amber-50 text-slate-800 leading-relaxed selection:bg-amber-200 selection:text-slate-900">
-  <header class="sticky top-0 z-50 bg-amber-700/90 supports-[backdrop-filter]:bg-amber-700/80 backdrop-blur text-white border-b border-amber-800/60">
-    <div class="relative mx-auto max-w-content px-4 py-3 flex items-center gap-3">
-      <a href="/" class="font-semibold tracking-tight text-white hover:text-amber-200 transition-colors">BibleProject Plans</a>
-      <span class="mobile-hide hidden sm:inline text-amber-100">· OT + NT with videos</span>
-      <button id="menu-button" aria-expanded="false" aria-controls="main-nav" class="ml-auto flex items-center gap-1 rounded-md px-2 py-1 text-sm text-amber-100 ring-1 ring-white/20 sm:hidden">
-        <span>Menu</span>
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-          <path d="M2 4h12v1H2V4zm0 3.5h12v1H2v-1zM2 11h12v1H2v-1z"/>
-        </svg>
-      </button>
-      <nav id="main-nav" class="hidden absolute top-full inset-x-4 mt-2 flex-col gap-2 rounded-md bg-amber-700/95 px-4 py-3 text-sm sm:static sm:ml-auto sm:mt-0 sm:flex sm:flex-row sm:gap-4 sm:bg-transparent sm:p-0">
-        <a class="text-amber-100 hover:text-white transition-colors" href="/">Home</a>
-        <a class="text-amber-100 hover:text-white transition-colors" href="/weeks/">Weeks</a>
-        <a class="inline-flex items-center gap-1 rounded-md bg-amber-500/90 px-2.5 py-1.5 text-white text-xs font-medium hover:bg-amber-400 transition-colors" href="/day/1/">Start</a>
-      </nav>
-    </div>
-  </header>
-  <main class="mx-auto max-w-content px-4 py-8 md:py-10">
-    {{ content }}
-  </main>
-  <footer class="mt-8 border-t border-amber-200">
-    <div class="mx-auto max-w-content px-4 py-6 text-xs text-amber-700 flex items-center justify-between">
-      <p>Built with Eleventy · Scripture data from BibleProject plans</p>
-      <a class="hover:text-amber-900 transition-colors" href="/">Back to top</a>
-    </div>
-  </footer>
+  <body class="min-h-full bg-bg text-text-primary leading-relaxed selection:bg-accent-teal/20 selection:text-text-primary">
+    <header class="border-b border-border bg-bg">
+      <div class="mx-auto max-w-content px-4 py-3 flex items-center gap-6">
+        <a href="/" class="font-serif text-lg text-text-primary hover:underline">BibleProject Plans</a>
+        <nav class="ml-auto flex gap-4 text-sm">
+          <a class="text-text-secondary hover:underline" href="/">Home</a>
+          <a class="text-text-secondary hover:underline" href="/weeks/">Weeks</a>
+          <a class="text-accent-teal hover:underline" href="/day/1/">Start</a>
+        </nav>
+      </div>
+    </header>
+    <main class="mx-auto max-w-content px-4 py-8 md:py-10">
+      {{ content }}
+    </main>
+    <footer class="mt-8 border-t border-border">
+      <div class="mx-auto max-w-content px-4 py-6 text-xs text-text-secondary flex items-center justify-between">
+        <p>Built with Eleventy · Scripture data from BibleProject plans</p>
+        <a class="hover:underline" href="/">Back to top</a>
+      </div>
+    </footer>
   <script src="/assets/app.js" defer></script>
   <script>
     // Register service worker for offline caching

--- a/src/assets/app.js
+++ b/src/assets/app.js
@@ -239,16 +239,16 @@
 
     function createDayCard(day) {
       return `
-        <div class="rounded-lg border border-slate-200 bg-white p-3 shadow-sm hover:shadow transition-shadow">
+        <div class="border border-border p-3 rounded-sm">
           <div class="flex items-center justify-between">
-            <div class="font-medium text-slate-900">Day ${day.day}</div>
+            <div class="font-medium">Day ${day.day}</div>
             <div class="flex items-center gap-1.5">
               ${day.hasJustice ? '<span class="text-sm" title="Justice scripture present">⭐</span>' : ''}
               ${day.hasVideos ? '<span class="text-sm" title="Has video">🎬</span>' : ''}
             </div>
           </div>
-          <div class="mt-1 text-sm text-slate-600">OT: ${day.otReading}</div>
-          <div class="text-sm text-slate-600">NT: ${day.ntReading}</div>
+          <div class="mt-1 text-sm text-text-secondary">OT: ${day.otReading}</div>
+          <div class="text-sm text-text-secondary">NT: ${day.ntReading}</div>
           <div class="mt-2"><a class="btn-primary" href="/day/${day.day}/">Open Day</a></div>
         </div>
       `;

--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -2,6 +2,49 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Design tokens */
+:root {
+  --color-bg: #FAFAF7;
+  --color-text-primary: #222222;
+  --color-text-secondary: #555555;
+  --color-accent-teal: #0C5A65;
+  --color-accent-orange: #D25B2D;
+  --color-border: #E5E5E5;
+
+  --font-serif: 'Merriweather', Georgia, serif;
+  --font-sans: 'Inter', Arial, sans-serif;
+
+  --font-size-h1: 32px;
+  --font-size-h2: 24px;
+  --font-size-h3: 18px;
+  --font-size-body: 16px;
+  --font-size-small: 14px;
+
+  --radius: 2px;
+  --transition: 0.15s ease-in-out;
+}
+
+@layer base {
+  body {
+    @apply bg-bg text-text-primary font-sans;
+  }
+  h1 {
+    @apply font-serif font-bold text-[32px];
+  }
+  h2 {
+    @apply font-serif text-[24px];
+  }
+  h3 {
+    @apply font-sans font-light text-[18px];
+  }
+  a {
+    @apply text-accent-teal underline hover:no-underline;
+  }
+  small {
+    @apply text-[14px] text-text-secondary;
+  }
+}
+
 /* Performance-optimized utilities */
 @layer utilities {
   .scroll-smooth {
@@ -20,18 +63,18 @@
 /* Button component styles */
 @layer components {
   .btn {
-    @apply inline-flex items-center rounded-md px-3 py-2 text-sm font-medium shadow-sm transition-colors;
+    @apply inline-flex items-center rounded-sm px-3 py-2 text-sm font-medium transition-colors;
   }
 
   .btn:focus {
-    @apply outline-none ring-2 ring-blue-500 ring-offset-2;
+    @apply outline-none ring-2 ring-accent-teal ring-offset-2;
   }
 
   .btn-primary {
-    @apply btn bg-blue-600 text-white hover:bg-blue-500;
+    @apply btn bg-accent-teal text-white hover:bg-accent-teal/90;
   }
 
   .btn-secondary {
-    @apply btn bg-amber-500/90 text-white hover:bg-amber-400;
+    @apply btn border border-border bg-transparent text-text-primary hover:bg-border;
   }
 }

--- a/src/days.liquid
+++ b/src/days.liquid
@@ -11,14 +11,14 @@ permalink: "/day/{{ d.day }}/"
 ---
 {% assign day = d.day %}
 <header class="mb-5 md:mb-6">
-  <h1 class="text-2xl md:text-[28px] font-semibold tracking-tight text-slate-900">Day {{ day }}{% if d.hasJustice %} <span class="align-middle text-base" title="Justice scripture present">⭐</span>{% endif %}</h1>
-  <p class="mt-1 text-slate-600">Old Testament and New Testament readings{% if d.videos and d.videos.size > 0 %} · Includes videos 🎬{% endif %}</p>
+  <h1>Day {{ day }}{% if d.hasJustice %} <span class="align-middle text-base" title="Justice scripture present">⭐</span>{% endif %}</h1>
+  <p class="mt-1 text-text-secondary">Old Testament and New Testament readings{% if d.videos and d.videos.size > 0 %} · Includes videos 🎬{% endif %}</p>
   <div class="mt-2.5 flex items-center gap-3 text-sm">
-    {% if day > 1 %}<a class="text-slate-600 hover:text-slate-900 inline-flex items-center gap-1" href="/day/{{ day | minus: 1 }}/">← Previous</a>{% endif %}
-    <span class="text-slate-300">|</span>
-    <a class="text-slate-600 hover:text-slate-900" href="/week/{{ day | minus: 1 | divided_by: 7 | floor | plus: 1 }}/">Back to Week</a>
-    <span class="text-slate-300">|</span>
-    {% if day < 365 %}<a class="text-slate-600 hover:text-slate-900 inline-flex items-center gap-1" href="/day/{{ day | plus: 1 }}/">Next →</a>{% endif %}
+    {% if day > 1 %}<a class="hover:underline inline-flex items-center gap-1" href="/day/{{ day | minus: 1 }}/">← Previous</a>{% endif %}
+    <span class="text-text-secondary">|</span>
+    <a class="hover:underline" href="/week/{{ day | minus: 1 | divided_by: 7 | floor | plus: 1 }}/">Back to Week</a>
+    <span class="text-text-secondary">|</span>
+    {% if day < 365 %}<a class="hover:underline inline-flex items-center gap-1" href="/day/{{ day | plus: 1 }}/">Next →</a>{% endif %}
   </div>
 </header>
 

--- a/src/index.liquid
+++ b/src/index.liquid
@@ -10,15 +10,15 @@ permalink: "/"
 {% assign this_week = plan.weeks | where: "weekNumber", current_week | first %}
 
 <header class="mb-5 md:mb-6">
-  <h1 class="text-2xl md:text-[28px] font-semibold tracking-tight text-slate-900">BibleProject Reading Plans</h1>
-  <p class="mt-1.5 text-slate-600">Today's reading and this week's plan, or <a class="text-blue-600 hover:text-blue-700 underline underline-offset-2" href="/weeks/">view by week</a>, or jump directly by scripture reference.</p>
+  <h1>BibleProject Reading Plans</h1>
+  <p class="mt-1.5 text-text-secondary">Today's reading and this week's plan, or <a class="text-accent-teal underline" href="/weeks/">view by week</a>, or jump directly by scripture reference.</p>
 </header>
 
 <section class="mb-6">
   <form id="scripture-form" action="/day/" method="get" class="flex flex-wrap items-center gap-3">
-    <label for="scripture" class="text-sm font-medium text-slate-700">Find a scripture:</label>
+    <label for="scripture" class="text-sm font-medium text-text-primary">Find a scripture:</label>
     <div class="flex-1 min-w-[260px] max-w-xl">
-      <input id="scripture" name="q" type="text" placeholder="e.g., James 1 or Genesis 1" autocomplete="off" class="block w-full rounded-md border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" />
+      <input id="scripture" name="q" type="text" placeholder="e.g., James 1 or Genesis 1" autocomplete="off" class="block w-full rounded-sm border border-border focus:border-accent-teal focus:ring-accent-teal" />
     </div>
     <button class="btn-primary" type="submit">Go</button>
   </form>
@@ -28,69 +28,69 @@ permalink: "/"
 <!-- Today's Reading -->
 {% if today_reading %}
 <section class="mb-8">
-  <h2 class="text-lg font-semibold text-slate-900 mb-3">Today's Reading - Day {{ current_day }}</h2>
-  <div class="bg-gradient-to-r from-blue-50 to-indigo-50 border border-blue-200 rounded-lg p-4 md:p-5">
-    <div class="flex items-center justify-between mb-3">
-      <div class="font-medium text-slate-900 text-lg">Day {{ today_reading.day }}</div>
-      <div class="flex items-center gap-1.5">
-        {% if today_reading.hasJustice %}<span class="text-base" title="Justice scripture present">⭐</span>{% endif %}
-        {% if today_reading.videos and today_reading.videos.size > 0 %}<span class="text-base" title="Has video">🎬</span>{% endif %}
+    <h2 class="text-lg font-semibold mb-3">Today's Reading - Day {{ current_day }}</h2>
+    <div class="p-4 md:p-5">
+      <div class="flex items-center justify-between mb-3">
+        <div class="font-medium text-lg">Day {{ today_reading.day }}</div>
+        <div class="flex items-center gap-1.5">
+          {% if today_reading.hasJustice %}<span class="text-base" title="Justice scripture present">⭐</span>{% endif %}
+          {% if today_reading.videos and today_reading.videos.size > 0 %}<span class="text-base" title="Has video">🎬</span>{% endif %}
+        </div>
       </div>
-    </div>
     {% include "scripture-readings.liquid" heading: "Old Testament", readings: today_reading.otReadings, url: today_reading.otUrl %}
     {% include "justice-scriptures.liquid" justice_refs: today_reading.justiceRefs %}
     {% include "scripture-readings.liquid" heading: "New Testament", readings: today_reading.ntReadings, url: today_reading.ntUrl, margin_top: "mt-4" %}
     {% if today_reading.videos and today_reading.videos.size > 0 %}
       {% include "videos-section.liquid" videos: today_reading.videos, heading_level: "h3", grid_classes: "grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3", margin_top: "mt-4" %}
     {% endif %}
-    <div class="mt-4">
-      <a class="btn-primary" href="/day/{{ today_reading.day }}/">View Full Day</a>
+      <div class="mt-4">
+        <a class="btn-primary" href="/day/{{ today_reading.day }}/">View Full Day</a>
+      </div>
     </div>
-  </div>
-</section>
+  </section>
 {% elsif current_day > 365 %}
-<section class="mb-8">
-  <h2 class="text-lg font-semibold text-slate-900 mb-3">Reading Plan Completed! 🎉</h2>
-  <div class="bg-gradient-to-r from-green-50 to-emerald-50 border border-green-200 rounded-lg p-4 md:p-5">
-    <p class="text-slate-700 mb-4">Congratulations! You've completed the 365-day reading plan. The plan covers days 1-365, and today would be day {{ current_day }}.</p>
-    <div class="space-y-2">
-      <a class="btn-primary" href="/day/365/">View Final Day (Day 365)</a>
-      <a class="btn-secondary ml-2" href="/day/1/">Start Over (Day 1)</a>
+  <section class="mb-8">
+    <h2 class="text-lg font-semibold mb-3">Reading Plan Completed! 🎉</h2>
+    <div class="p-4 md:p-5">
+      <p class="mb-4">Congratulations! You've completed the 365-day reading plan. The plan covers days 1-365, and today would be day {{ current_day }}.</p>
+      <div class="space-y-2">
+        <a class="btn-primary" href="/day/365/">View Final Day (Day 365)</a>
+        <a class="btn-secondary ml-2" href="/day/1/">Start Over (Day 1)</a>
+      </div>
     </div>
-  </div>
-</section>
+  </section>
 {% else %}
-<section class="mb-8">
-  <h2 class="text-lg font-semibold text-slate-900 mb-3">Today's Reading - Day {{ current_day }}</h2>
-  <div class="bg-gradient-to-r from-yellow-50 to-amber-50 border border-yellow-200 rounded-lg p-4 md:p-5">
-    <p class="text-slate-700 mb-4">No reading found for day {{ current_day }}. This might be due to data not being available.</p>
-    <div class="space-y-2">
-      <a class="btn-primary" href="/day/1/">Go to Day 1</a>
-      <a class="btn-secondary ml-2" href="/weeks/">Browse by Week</a>
+  <section class="mb-8">
+    <h2 class="text-lg font-semibold mb-3">Today's Reading - Day {{ current_day }}</h2>
+    <div class="p-4 md:p-5">
+      <p class="mb-4">No reading found for day {{ current_day }}. This might be due to data not being available.</p>
+      <div class="space-y-2">
+        <a class="btn-primary" href="/day/1/">Go to Day 1</a>
+        <a class="btn-secondary ml-2" href="/weeks/">Browse by Week</a>
+      </div>
     </div>
-  </div>
-</section>
+  </section>
 {% endif %}
 
 <!-- This Week's Readings -->
 {% if this_week %}
 <section class="mb-8">
-  <h2 class="text-lg font-semibold text-slate-900 mb-3">This Week - Week {{ current_week }}</h2>
+  <h2 class="text-lg font-semibold mb-3">This Week - Week {{ current_week }}</h2>
   <div class="space-y-3">
     {% for day in this_week.days %}
-      <div class="rounded-lg border border-slate-200 bg-white p-3 {% if day.day == current_day %}ring-2 ring-blue-200 bg-blue-50{% endif %}">
+      <div class="border border-border p-3 rounded-sm">
         <div class="flex items-center justify-between">
-          <div class="font-medium text-slate-900">
+          <div class="font-medium">
             {% if day.day == current_day %}📍 {% endif %}Day {{ day.day }}
-            {% if day.day == current_day %}<span class="text-sm text-blue-600 font-normal">(Today)</span>{% endif %}
+            {% if day.day == current_day %}<span class="text-sm text-accent-teal font-normal">(Today)</span>{% endif %}
           </div>
           <div class="flex items-center gap-1.5">
             {% if day.hasJustice %}<span class="text-sm" title="Justice scripture present">⭐</span>{% endif %}
             {% if day.videos and day.videos.size > 0 %}<span class="text-sm" title="Has video">🎬</span>{% endif %}
           </div>
         </div>
-        <div class="mt-1 text-sm text-slate-600">OT: {% if day.otReadings.size > 0 %}{{ day.otReadings | join: "; " }}{% else %}-{% endif %}</div>
-        <div class="text-sm text-slate-600">NT: {% if day.ntReadings.size > 0 %}{{ day.ntReadings | join: "; " }}{% else %}-{% endif %}</div>
+        <div class="mt-1 text-sm text-text-secondary">OT: {% if day.otReadings.size > 0 %}{{ day.otReadings | join: "; " }}{% else %}-{% endif %}</div>
+        <div class="text-sm text-text-secondary">NT: {% if day.ntReadings.size > 0 %}{{ day.ntReadings | join: "; " }}{% else %}-{% endif %}</div>
         <div class="mt-2">
           <a class="{% if day.day == current_day %}btn-primary{% else %}btn-secondary{% endif %}" href="/day/{{ day.day }}/">Open Day</a>
         </div>
@@ -103,9 +103,9 @@ permalink: "/"
 </section>
 {% elsif current_week > 53 %}
 <section class="mb-8">
-  <h2 class="text-lg font-semibold text-slate-900 mb-3">Week {{ current_week }} - Beyond Plan</h2>
-  <div class="bg-gradient-to-r from-green-50 to-emerald-50 border border-green-200 rounded-lg p-4 md:p-5">
-    <p class="text-slate-700 mb-4">You're beyond the 53-week reading plan! The plan covers weeks 1-53.</p>
+  <h2 class="text-lg font-semibold mb-3">Week {{ current_week }} - Beyond Plan</h2>
+  <div class="p-4 md:p-5">
+    <p class="mb-4">You're beyond the 53-week reading plan! The plan covers weeks 1-53.</p>
     <div class="space-y-2">
       <a class="btn-primary" href="/week/53/">View Final Week (Week 53)</a>
       <a class="btn-secondary ml-2" href="/week/1/">Start Over (Week 1)</a>
@@ -114,20 +114,20 @@ permalink: "/"
 </section>
 {% endif %}
 
-<h2 class="text-base font-semibold text-slate-900 mb-2.5">All Days</h2>
+<h2 class="text-base font-semibold mb-2.5">All Days</h2>
 <div id="days-grid" class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
   {% assign days_to_show = plan.days | slice: 0, 30 %}
   {% for d in days_to_show %}
-    <div class="rounded-lg border border-slate-200 bg-white p-3 shadow-sm hover:shadow transition-shadow">
+    <div class="border border-border p-3 rounded-sm">
       <div class="flex items-center justify-between">
-        <div class="font-medium text-slate-900">Day {{ d.day }}</div>
+        <div class="font-medium">Day {{ d.day }}</div>
         <div class="flex items-center gap-1.5">
           {% if d.hasJustice %}<span class="text-sm" title="Justice scripture present">⭐</span>{% endif %}
           {% if d.videos and d.videos.size > 0 %}<span class="text-sm" title="Has video">🎬</span>{% endif %}
         </div>
       </div>
-      <div class="mt-1 text-sm text-slate-600">OT: {% if d.otReadings.size > 0 %}{{ d.otReadings[0] }}{% else %}-{% endif %}</div>
-      <div class="text-sm text-slate-600">NT: {% if d.ntReadings.size > 0 %}{{ d.ntReadings[0] }}{% else %}-{% endif %}</div>
+      <div class="mt-1 text-sm text-text-secondary">OT: {% if d.otReadings.size > 0 %}{{ d.otReadings[0] }}{% else %}-{% endif %}</div>
+      <div class="text-sm text-text-secondary">NT: {% if d.ntReadings.size > 0 %}{{ d.ntReadings[0] }}{% else %}-{% endif %}</div>
       <div class="mt-2"><a class="btn-primary" href="/day/{{ d.day }}/">Open Day</a></div>
     </div>
   {% endfor %}
@@ -137,8 +137,8 @@ permalink: "/"
   <button id="load-more-days" class="btn-secondary" data-loaded="30" data-total="{{ plan.days.size }}">
     Load More Days ({{ plan.days.size | minus: 30 }} remaining)
   </button>
-  <div class="mt-2 text-sm text-slate-600">
-    Or <a class="text-blue-600 hover:text-blue-700 underline underline-offset-2" href="/weeks/">view by week</a> for faster browsing
+  <div class="mt-2 text-sm text-text-secondary">
+    Or <a class="text-accent-teal underline" href="/weeks/">view by week</a> for faster browsing
   </div>
 </div>
 

--- a/src/week.liquid
+++ b/src/week.liquid
@@ -11,20 +11,20 @@ permalink: "/week/{{ w.weekNumber }}/"
 ---
 {% assign week = w %}
 <header class="mb-5 md:mb-6">
-  <h1 class="text-2xl md:text-[28px] font-semibold tracking-tight text-slate-900">Week {{ week.weekNumber }}{% if week.hasJustice %} <span class="align-middle text-base" title="Justice scripture present">⭐</span>{% endif %}</h1>
-  <p class="mt-1 text-slate-600">Old Testament and New Testament readings for the week.</p>
+  <h1>Week {{ week.weekNumber }}{% if week.hasJustice %} <span class="align-middle text-base" title="Justice scripture present">⭐</span>{% endif %}</h1>
+  <p class="mt-1 text-text-secondary">Old Testament and New Testament readings for the week.</p>
   <div class="mt-2.5 flex items-center gap-3 text-sm">
-    {% if week.weekNumber > 1 %}<a class="text-slate-600 hover:text-slate-900 inline-flex items-center gap-1" href="/week/{{ week.weekNumber | minus: 1 }}/">← Previous Week</a>{% endif %}
-    <span class="text-slate-300">|</span>
-    {% if week.weekNumber < 53 %}<a class="text-slate-600 hover:text-slate-900 inline-flex items-center gap-1" href="/week/{{ week.weekNumber | plus: 1 }}/">Next Week →</a>{% endif %}
+    {% if week.weekNumber > 1 %}<a class="hover:underline inline-flex items-center gap-1" href="/week/{{ week.weekNumber | minus: 1 }}/">← Previous Week</a>{% endif %}
+    <span class="text-text-secondary">|</span>
+    {% if week.weekNumber < 53 %}<a class="hover:underline inline-flex items-center gap-1" href="/week/{{ week.weekNumber | plus: 1 }}/">Next Week →</a>{% endif %}
   </div>
 </header>
 
 <div class="space-y-8">
 {% for day in week.days %}
-<article class="border-t border-slate-200 pt-8">
+<article class="border-t border-border pt-8">
   <header class="flex items-center justify-between">
-    <h2 class="text-xl font-semibold text-slate-800">
+    <h2 class="text-xl font-semibold">
       <a href="/day/{{ day.day }}/" class="hover:underline">Day {{ day.day }}{% if day.hasJustice %} <span class="align-middle text-base" title="Justice scripture present">⭐</span>{% endif %}</a>
     </h2>
   </header>

--- a/src/weeks.liquid
+++ b/src/weeks.liquid
@@ -5,19 +5,19 @@ description: "A weekly overview of the BibleProject reading plan."
 permalink: "/weeks/"
 ---
 <header class="mb-5 md:mb-6">
-  <h1 class="text-2xl md:text-[28px] font-semibold tracking-tight text-slate-900">Weekly Reading Plan</h1>
-  <p class="mt-1 text-slate-600">A weekly overview of the BibleProject reading plan.</p>
+  <h1>Weekly Reading Plan</h1>
+  <p class="mt-1 text-text-secondary">A weekly overview of the BibleProject reading plan.</p>
 </header>
 
 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
   {% for week in plan.weeks %}
     <a
       href="/week/{{ week.weekNumber }}/"
-      class="rounded-lg border border-slate-200 bg-white p-4 shadow-sm hover:border-blue-500 hover:bg-blue-50"
+      class="border border-border p-4 rounded-sm hover:bg-border"
     >
-      <div class="font-semibold text-slate-900">Week {{ week.weekNumber }}</div>
-      <div class="text-sm text-slate-500">Days {{ week.days[0].day }}-{{ week.days.last.day }}</div>
-      {% if week.hasJustice %}<div class="mt-1 text-xs text-slate-500" title="This week contains a justice-themed scripture">⭐ Justice</div>{% endif %}
+      <div class="font-semibold">Week {{ week.weekNumber }}</div>
+      <div class="text-sm text-text-secondary">Days {{ week.days[0].day }}-{{ week.days.last.day }}</div>
+      {% if week.hasJustice %}<div class="mt-1 text-xs text-text-secondary" title="This week contains a justice-themed scripture">⭐ Justice</div>{% endif %}
     </a>
   {% endfor %}
 </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,20 +8,30 @@ module.exports = {
     extend: {
       fontFamily: {
         sans: [
-          "ui-sans-serif",
-          "system-ui", 
-          "-apple-system",
-          "Segoe UI",
-          "Roboto",
-          "Helvetica Neue",
-          "Arial",
-          "Noto Sans",
-          "Apple Color Emoji",
-          "Segoe UI Emoji"
+          'Inter',
+          'Arial',
+          'sans-serif',
+        ],
+        serif: [
+          'Merriweather',
+          'Georgia',
+          'serif',
         ],
       },
-      maxWidth: { 
-        'content': '56rem' 
+      colors: {
+        bg: '#FAFAF7',
+        border: '#E5E5E5',
+        text: {
+          primary: '#222222',
+          secondary: '#555555',
+        },
+        accent: {
+          teal: '#0C5A65',
+          orange: '#D25B2D',
+        },
+      },
+      maxWidth: {
+        'content': '56rem'
       },
     }
   },


### PR DESCRIPTION
## Summary
- Replace bright theme with neutral serif/sans palette and new design tokens
- Simplify layout and components for hierarchy and whitespace
- Update buttons and links to muted teal and orange accents

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run site:build`

------
https://chatgpt.com/codex/tasks/task_e_68b4552cf79c8322953b998a4537fdf6